### PR TITLE
Replace anchor tags with Router.Link for client-side navigation

### DIFF
--- a/docs-website/src/App.res
+++ b/docs-website/src/App.res
@@ -43,15 +43,15 @@ let make = () => {
   let sectionsSignal = Computed.make(() => makeSections(Signal.get(currentPath)))
 
   let logo =
-    <a href="/" style="text-decoration: none; color: inherit;">
+    <Router.Link to="/" style="text-decoration: none; color: inherit;">
       <Typography text={static("ReScript Signals")} variant={H4} />
-    </a>
+    </Router.Link>
 
   let topbarLeft =
-    <a href="/" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 0.75rem;">
+    <Router.Link to="/" style="text-decoration: none; color: inherit; display: flex; align-items: center; gap: 0.75rem;">
       <Typography text={static("ReScript Signals")} variant={H5} />
       <Badge label={Signal.make("v" ++ version)} variant={Secondary} />
-    </a>
+    </Router.Link>
 
   let topbarRight =
     <div style="display: flex; align-items: center; gap: 1rem;">

--- a/docs-website/src/Main.res
+++ b/docs-website/src/Main.res
@@ -2,5 +2,5 @@ open Xote
 
 %%raw(`import './styles.css'`)
 
-Router.init()
+Router.init(~basePath="/rescript-signals", ())
 Component.mountById(<App />, "app")

--- a/docs-website/src/components/Breadcrumbs.res
+++ b/docs-website/src/components/Breadcrumbs.res
@@ -46,9 +46,9 @@ let make = () => {
                   switch crumb.url {
                   | Some(url) =>
                     <span>
-                      <a href={url} style="color: var(--basefn-color-muted); text-decoration: none;">
+                      <Router.Link to={url} style="color: var(--basefn-color-muted); text-decoration: none;">
                         {crumb.label->Component.text}
-                      </a>
+                      </Router.Link>
                       {separator}
                     </span>
                   | None =>

--- a/docs-website/src/components/PageNavigation.res
+++ b/docs-website/src/components/PageNavigation.res
@@ -54,12 +54,12 @@ let make = () => {
       Computed.make(() => {
         switch Signal.get(prevPage) {
         | Some(page) => [
-            <a
-              href={page.url}
+            <Router.Link
+              to={page.url}
               style="display: flex; flex-direction: column; text-decoration: none; color: inherit;">
               <Typography text={static("Previous")} variant={Small} />
               <Typography text={static(page.label)} variant={H5} />
-            </a>,
+            </Router.Link>,
           ]
         | None => [<div />]
         }
@@ -69,12 +69,12 @@ let make = () => {
       Computed.make(() => {
         switch Signal.get(nextPage) {
         | Some(page) => [
-            <a
-              href={page.url}
+            <Router.Link
+              to={page.url}
               style="display: flex; flex-direction: column; align-items: flex-end; text-decoration: none; color: inherit; margin-left: auto;">
               <Typography text={static("Next")} variant={Small} />
               <Typography text={static(page.label)} variant={H5} />
-            </a>,
+            </Router.Link>,
           ]
         | None => [<div />]
         }


### PR DESCRIPTION
## Summary
This PR updates the documentation website to use the `Router.Link` component instead of standard HTML anchor tags (`<a>`) for internal navigation. This enables client-side routing instead of full page reloads, improving the user experience. Additionally, the Router is initialized with a base path to support deployment in a subdirectory.

## Key Changes
- **PageNavigation.res**: Replaced `<a>` tags with `<Router.Link>` for previous/next page navigation links
- **App.res**: Replaced `<a>` tags with `<Router.Link>` for logo and header navigation links
- **Breadcrumbs.res**: Replaced `<a>` tags with `<Router.Link>` for breadcrumb navigation links
- **Main.res**: Updated `Router.init()` call to include `~basePath="/rescript-signals"` parameter for proper routing in subdirectory deployment

## Implementation Details
- All `href` attributes were converted to `to` attributes to match the `Router.Link` API
- Styling and other attributes were preserved during the conversion
- The base path configuration allows the documentation site to be deployed at a subdirectory URL while maintaining correct routing behavior

https://claude.ai/code/session_01Rjq6HzjqRpM3dy846r1Vmj