### PR TITLE
Enable SSR prerendering for docs website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,11 +35,7 @@ jobs:
         working-directory: docs-website
         run: npm ci
 
-      - name: Build ReScript
-        working-directory: docs-website
-        run: npm run res:build
-
-      - name: Build Vite
+      - name: Build
         working-directory: docs-website
         run: npm run build
 
@@ -49,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs-website/dist
+          path: docs-website/build/client
 
   deploy:
     name: Deploy

--- a/docs-website/.gitignore
+++ b/docs-website/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+build
 .vite
 *.res.mjs
 lib

--- a/docs-website/index.html
+++ b/docs-website/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to content</a>
-  <div id="app"></div>
+  <div id="app"><!--ssr-outlet--></div>
   <script type="module" src="/src/Main.res.mjs"></script>
 </body>
 </html>

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "rescript -w & vite",
-    "build": "rescript && vite build",
+    "build": "npm run res:build && npm run build:client && npm run build:server && npm run build:prerender",
+    "build:client": "vite build",
+    "build:server": "vite build --ssr src/EntryServer.res.mjs --outDir build/server",
+    "build:prerender": "node scripts/prerender.mjs",
     "preview": "vite preview",
     "res:build": "rescript",
     "res:watch": "rescript -w",

--- a/docs-website/scripts/prerender.mjs
+++ b/docs-website/scripts/prerender.mjs
@@ -1,0 +1,72 @@
+/**
+ * Pre-render all docs website routes to static HTML files.
+ *
+ * This script runs after `vite build` (client + server bundles) and uses
+ * the SSR server entry to render each route into its own index.html file,
+ * making the site compatible with static hosting (e.g., GitHub Pages).
+ *
+ * Usage: node scripts/prerender.mjs
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const buildDir = path.join(__dirname, '..', 'build', 'client')
+
+// All routes to pre-render (app-relative paths, without base path)
+const routes = [
+  '/',
+  '/getting-started',
+  '/api/signal',
+  '/api/computed',
+  '/api/effect',
+  '/examples',
+  '/release-notes',
+]
+
+// Suppress expected SSR errors from client-only code
+process.on('uncaughtException', (err) => {
+  if (err.message?.includes('document is not defined') ||
+      err.message?.includes('window is not defined')) {
+    return
+  }
+  console.error('Uncaught exception:', err)
+  process.exit(1)
+})
+
+async function prerender() {
+  // Read the built index.html template (produced by vite build)
+  const template = fs.readFileSync(path.join(buildDir, 'index.html'), 'utf-8')
+
+  // Load the SSR server entry (built by vite build --ssr)
+  const { render } = await import('../build/server/EntryServer.res.js')
+
+  console.log(`Pre-rendering ${routes.length} routes...\n`)
+
+  for (const route of routes) {
+    // Render the app HTML for this route
+    const appHtml = render(route)
+
+    // Inject into the template
+    const html = template.replace('<!--ssr-outlet-->', appHtml)
+
+    // Write to the correct directory structure
+    // e.g., "/" → build/client/index.html (already exists, overwrite)
+    //        "/getting-started" → build/client/getting-started/index.html
+    const filePath = route === '/'
+      ? path.join(buildDir, 'index.html')
+      : path.join(buildDir, route, 'index.html')
+
+    // Ensure directory exists
+    const dir = path.dirname(filePath)
+    fs.mkdirSync(dir, { recursive: true })
+
+    fs.writeFileSync(filePath, html)
+    console.log(`  ${route} → ${path.relative(buildDir, filePath)}`)
+  }
+
+  console.log('\nPre-rendering complete!')
+}
+
+prerender()

--- a/docs-website/src/EntryServer.res
+++ b/docs-website/src/EntryServer.res
@@ -1,0 +1,13 @@
+open Xote
+
+// Import modules to ensure they are included in the bundle
+module Website = Website
+
+// Render function called by the SSR server for each request
+let render = (url: string) => {
+  // Initialize router for server-side rendering with the requested URL
+  Router.initSSR(~basePath="/rescript-signals", ~pathname=url, ())
+
+  // Render the app to an HTML string
+  SSR.renderToString(() => <Website.App />)
+}

--- a/docs-website/vite.config.js
+++ b/docs-website/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from "vite"
 export default defineConfig({
   base: "/rescript-signals/",
   build: {
-    outDir: "dist",
+    outDir: "build/client",
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
Add static HTML prerendering so the docs site serves pre-rendered content on GitHub Pages instead of an empty shell. This improves SEO and initial page load performance.

- Add EntryServer.res as the SSR entry point using Xote SSR.renderToString
- Add scripts/prerender.mjs to generate static HTML for all routes
- Update build pipeline: client build → server build → prerender
- Update vite output to build/client, add build/server for SSR bundle
- Add <!--ssr-outlet--> marker in index.html for HTML injection
- Update GitHub Actions workflow to deploy from build/client
