### PR TITLE
Fix SSR and add GitHub Pages SPA routing support

### DIFF
--- a/docs-website/index.html
+++ b/docs-website/index.html
@@ -12,6 +12,21 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=Geist+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
 </head>
 <body>
+  <!-- SPA redirect decoder for GitHub Pages (counterpart to 404.html) -->
+  <script>
+    (function() {
+      var redirect = window.location.search.match(/^\?\/(.*)/);
+      if (redirect) {
+        var decoded = redirect[1].split('&').map(function(s) {
+          return s.replace(/~and~/g, '&');
+        }).join('?');
+        var basePath = '/rescript-signals';
+        window.history.replaceState(null, '',
+          basePath + '/' + decoded + window.location.hash
+        );
+      }
+    })();
+  </script>
   <a href="#main-content" class="skip-to-content">Skip to content</a>
   <div id="app"><!--ssr-outlet--></div>
   <script type="module" src="/src/Main.res.mjs"></script>

--- a/docs-website/public/404.html
+++ b/docs-website/public/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    // SPA redirect for GitHub Pages
+    // See: https://github.com/rafgraph/spa-github-pages
+    var pathSegmentsToKeep = 1; // Keep '/rescript-signals' prefix (1 segment)
+    var l = window.location;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+      l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+      (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+      l.hash
+    );
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/docs-website/scripts/prerender.mjs
+++ b/docs-website/scripts/prerender.mjs
@@ -45,29 +45,46 @@ async function prerender() {
 
   console.log(`Pre-rendering ${routes.length} routes...\n`)
 
+  let rendered = 0
+  let failed = 0
+
   for (const route of routes) {
-    // Render the app HTML for this route
-    const appHtml = render(route)
+    try {
+      // Render the app HTML for this route
+      const appHtml = render(route)
 
-    // Inject into the template
-    const html = template.replace('<!--ssr-outlet-->', appHtml)
+      // Inject into the template
+      const html = template.replace('<!--ssr-outlet-->', appHtml)
 
-    // Write to the correct directory structure
-    // e.g., "/" → build/client/index.html (already exists, overwrite)
-    //        "/getting-started" → build/client/getting-started/index.html
-    const filePath = route === '/'
-      ? path.join(buildDir, 'index.html')
-      : path.join(buildDir, route, 'index.html')
+      // Write to the correct directory structure
+      // e.g., "/" → build/client/index.html (already exists, overwrite)
+      //        "/getting-started" → build/client/getting-started/index.html
+      const filePath = route === '/'
+        ? path.join(buildDir, 'index.html')
+        : path.join(buildDir, route, 'index.html')
 
-    // Ensure directory exists
-    const dir = path.dirname(filePath)
-    fs.mkdirSync(dir, { recursive: true })
+      // Ensure directory exists
+      const dir = path.dirname(filePath)
+      fs.mkdirSync(dir, { recursive: true })
 
-    fs.writeFileSync(filePath, html)
-    console.log(`  ${route} → ${path.relative(buildDir, filePath)}`)
+      fs.writeFileSync(filePath, html)
+      console.log(`  ✓ ${route} → ${path.relative(buildDir, filePath)}`)
+      rendered++
+    } catch (err) {
+      // Write the template without SSR content as a fallback so the route
+      // still works via client-side rendering on page refresh.
+      const filePath = route === '/'
+        ? path.join(buildDir, 'index.html')
+        : path.join(buildDir, route, 'index.html')
+      const dir = path.dirname(filePath)
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(filePath, template)
+      console.warn(`  ~ ${route} → ${path.relative(buildDir, filePath)} (client-only fallback: ${err.message})`)
+      failed++
+    }
   }
 
-  console.log('\nPre-rendering complete!')
+  console.log(`\nPre-rendering complete! (${rendered} rendered, ${failed} skipped)`)
 }
 
 prerender()

--- a/docs-website/src/Layout.res
+++ b/docs-website/src/Layout.res
@@ -38,13 +38,15 @@ let toggleTheme = () => {
   )
 }
 
-let _ = Effect.run(() => {
-  let t = Signal.get(theme)
-  setHtmlAttribute("data-theme", t)
-  setItem("rescript-signals-theme", t)
-  Basefn.Theme.applyTheme(t == "dark" ? Basefn.Theme.Dark : Basefn.Theme.Light)
-  None
-})->ignore
+let _ = if isBrowser {
+  Effect.run(() => {
+    let t = Signal.get(theme)
+    setHtmlAttribute("data-theme", t)
+    setItem("rescript-signals-theme", t)
+    Basefn.Theme.applyTheme(t == "dark" ? Basefn.Theme.Dark : Basefn.Theme.Light)
+    None
+  })->ignore
+}
 
 // ---- Search state ----
 let searchOpen = Signal.make(false)
@@ -244,14 +246,16 @@ module Header = {
 
   let make = (_props: props) => {
     // Scroll listener
-    let _ = Effect.run(() => {
-      let handleScroll = () => {
-        let scrollY: float = %raw(`window.scrollY`)
-        Signal.set(isScrolled, scrollY > 10.0)
-      }
-      addEventListener("scroll", handleScroll)
-      Some(() => removeEventListener("scroll", handleScroll))
-    })->ignore
+    let _ = if isBrowser {
+      Effect.run(() => {
+        let handleScroll = () => {
+          let scrollY: float = %raw(`window.scrollY`)
+          Signal.set(isScrolled, scrollY > 10.0)
+        }
+        addEventListener("scroll", handleScroll)
+        Some(() => removeEventListener("scroll", handleScroll))
+      })->ignore
+    }
 
     Component.element(
       "header",
@@ -456,22 +460,24 @@ module Footer = {
 }
 
 // ---- Global Cmd+K shortcut ----
-let _ = Effect.run(() => {
-  let handler = (_evt: Dom.event) => {
-    let ctrlOrMeta: bool = %raw(`_evt.ctrlKey || _evt.metaKey`)
-    let key: string = %raw(`_evt.key`)
-    if ctrlOrMeta && key == "k" {
-      let _ = %raw(`_evt.preventDefault()`)
-      if Signal.peek(searchOpen) {
-        closeSearch()
-      } else {
-        openSearch()
+let _ = if isBrowser {
+  Effect.run(() => {
+    let handler = (_evt: Dom.event) => {
+      let ctrlOrMeta: bool = %raw(`_evt.ctrlKey || _evt.metaKey`)
+      let key: string = %raw(`_evt.key`)
+      if ctrlOrMeta && key == "k" {
+        let _ = %raw(`_evt.preventDefault()`)
+        if Signal.peek(searchOpen) {
+          closeSearch()
+        } else {
+          openSearch()
+        }
       }
     }
-  }
-  addEventListener("keydown", handler)
-  Some(() => removeEventListener("keydown", handler))
-})->ignore
+    addEventListener("keydown", handler)
+    Some(() => removeEventListener("keydown", handler))
+  })->ignore
+}
 
 // ---- Main layout wrapper ----
 type props = {children: Component.node}


### PR DESCRIPTION
## Summary
This PR improves the documentation website's server-side rendering (SSR) safety and adds support for GitHub Pages SPA routing with proper 404 handling.

## Key Changes

- **SSR Safety**: Wrapped browser-dependent effects in `isBrowser` guards in `Layout.res`
  - Theme initialization effect now only runs in browser environment
  - Scroll listener in Header component protected with `isBrowser` check
  - Global Cmd+K keyboard shortcut handler protected with `isBrowser` check

- **Improved Pre-rendering**: Enhanced `prerender.mjs` with error handling and fallback rendering
  - Added try-catch blocks around route rendering to gracefully handle failures
  - Routes that fail SSR rendering fall back to client-side rendering via template-only output
  - Added progress tracking with rendered/failed counts in console output
  - Improved logging with visual indicators (✓ for success, ~ for fallback)

- **GitHub Pages SPA Support**: Added proper routing configuration for GitHub Pages deployment
  - Created `public/404.html` with SPA redirect script (based on spa-github-pages pattern)
  - Added redirect decoder script in `index.html` to restore proper URLs after GitHub Pages redirect
  - Maintains `/rescript-signals` base path prefix for correct routing

## Implementation Details

The `isBrowser` guard prevents runtime errors during SSR by ensuring DOM-dependent code only executes in browser environments. The pre-rendering error handling ensures the build completes successfully even if individual routes fail to render, with fallback to client-side rendering. The GitHub Pages routing solution uses a standard SPA pattern where 404s redirect to index.html with the original path encoded in the query string, which is then decoded and restored on page load.

https://claude.ai/code/session_01FmSArqxrD6RxSCaPZAApM9