### PR TITLE
Remove H1 typography headers from page components

### DIFF
--- a/docs-website/src/pages/Pages__ApiComputed.res
+++ b/docs-website/src/pages/Pages__ApiComputed.res
@@ -5,7 +5,6 @@ open Basefn
 @jsx.component
 let make = () => {
   <div>
-    <Typography text={static("Computed")} variant={H1} />
     <Typography
       text={static("Derived values that automatically update when their dependencies change.")}
       variant={Lead}

--- a/docs-website/src/pages/Pages__ApiEffect.res
+++ b/docs-website/src/pages/Pages__ApiEffect.res
@@ -5,7 +5,6 @@ open Basefn
 @jsx.component
 let make = () => {
   <div>
-    <Typography text={static("Effect")} variant={H1} />
     <Typography
       text={static("Side effects that automatically re-run when their dependencies change.")}
       variant={Lead}

--- a/docs-website/src/pages/Pages__ApiSignal.res
+++ b/docs-website/src/pages/Pages__ApiSignal.res
@@ -5,7 +5,6 @@ open Basefn
 @jsx.component
 let make = () => {
   <div>
-    <Typography text={static("Signal")} variant={H1} />
     <Typography
       text={static("The core reactive primitive for holding mutable state.")}
       variant={Lead}

--- a/docs-website/src/pages/Pages__Examples.res
+++ b/docs-website/src/pages/Pages__Examples.res
@@ -171,7 +171,6 @@ module DerivedStateExample = {
 let make = () => {
   <div>
     <div>
-      <Typography text={static("Examples")} variant={H1} />
       <Typography
         text={static("Interactive examples demonstrating rescript-signals patterns.")}
         variant={Lead}

--- a/docs-website/src/pages/Pages__GettingStarted.res
+++ b/docs-website/src/pages/Pages__GettingStarted.res
@@ -4,7 +4,6 @@ open Basefn
 @jsx.component
 let make = () => {
   <div>
-    <Typography text={static("Getting Started")} variant={H1} />
     <Typography
       text={static("Learn how to install and use rescript-signals in your project.")}
       variant={Lead}

--- a/docs-website/src/pages/Pages__ReleaseNotes.res
+++ b/docs-website/src/pages/Pages__ReleaseNotes.res
@@ -73,7 +73,6 @@ let make = () => {
 
   <div>
     <div>
-      <Typography text={static("Release Notes")} variant={H1} />
       <Typography
         text={static("View the changelog and release history for rescript-signals.")}
         variant={Lead}


### PR DESCRIPTION
## Summary
Removed redundant H1 typography headers from all main page components in the documentation website. These headers were duplicating page titles that are likely managed elsewhere in the layout hierarchy.

## Changes
- Removed `<Typography text={static("Computed")} variant={H1} />` from `Pages__ApiComputed.res`
- Removed `<Typography text={static("Effect")} variant={H1} />` from `Pages__ApiEffect.res`
- Removed `<Typography text={static("Signal")} variant={H1} />` from `Pages__ApiSignal.res`
- Removed `<Typography text={static("Examples")} variant={H1} />` from `Pages__Examples.res`
- Removed `<Typography text={static("Getting Started")} variant={H1} />` from `Pages__GettingStarted.res`
- Removed `<Typography text={static("Release Notes")} variant={H1} />` from `Pages__ReleaseNotes.res`

## Details
All page components retained their secondary typography elements (variant={Lead}) which serve as descriptive subtitles. The removal of H1 headers suggests these page titles are now being managed at a higher level in the page layout structure, reducing duplication and improving maintainability.

https://claude.ai/code/session_016FU2gYqPVqBLQiFadPNpxM