### PR TITLE
Add prepack and postpack scripts to clean dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "build": "rescript",
     "clean": "rescript clean",
     "prepare": "husky",
+    "prepack": "node scripts/prepack.js",
+    "postpack": "node scripts/postpack.js",
     "semantic-release": "semantic-release"
   },
   "repository": {

--- a/scripts/postpack.js
+++ b/scripts/postpack.js
@@ -1,0 +1,3 @@
+const fs = require("fs");
+
+fs.renameSync("rescript.json.bak", "rescript.json");

--- a/scripts/prepack.js
+++ b/scripts/prepack.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const file = "rescript.json";
+
+fs.cpSync(file, file + ".bak");
+
+const config = JSON.parse(fs.readFileSync(file, "utf8"));
+config.sources = config.sources.filter((s) => s.type !== "dev");
+delete config["dev-dependencies"];
+
+fs.writeFileSync(file, JSON.stringify(config, null, 2) + "\n");


### PR DESCRIPTION
## Summary
This PR adds npm lifecycle scripts to automatically remove development dependencies from the package configuration during the packing process, ensuring that published packages don't include dev-only sources and dependencies.

## Key Changes
- **scripts/prepack.js**: New script that runs before packing
  - Creates a backup of `rescript.json`
  - Filters out sources with `type: "dev"`
  - Removes the `dev-dependencies` field from the config
  - Writes the cleaned config back to `rescript.json`

- **scripts/postpack.js**: New script that runs after packing
  - Restores the original `rescript.json` from the backup

- **package.json**: Added npm lifecycle hooks
  - `prepack`: Executes the prepack script to clean the configuration
  - `postpack`: Executes the postpack script to restore the original configuration

## Implementation Details
The scripts use a backup-and-restore pattern to ensure the repository's working state remains unchanged while the published package contains only production dependencies. This approach is non-destructive and maintains the original configuration for local development.

https://claude.ai/code/session_01HCftKApbn1t3zgBkgBMZ86