### PR TITLE
feat: add Effect.ignore function

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,9 @@ let run: (
   unit => option<unit => unit>,
   ~name: option<string>=?
 ) => disposer
+
+// Discard the disposer for fire-and-forget effects
+let ignore: disposer => unit
 ```
 
 **Parameters:**
@@ -405,6 +408,8 @@ let run: (
 - `~name`: Optional name for debugging
 
 **Returns:** A disposer object with a `dispose()` method
+
+**`Effect.ignore`**: Explicitly discards the disposer for fire-and-forget effects where manual disposal isn't needed.
 
 **Note:** Effects run immediately and re-run whenever tracked dependencies change. Cleanup functions run before re-execution and on disposal.
 

--- a/docs-website/src/pages/Pages__ApiEffect.res
+++ b/docs-website/src/pages/Pages__ApiEffect.res
@@ -102,6 +102,23 @@ disposer.dispose()
 // Future changes won't trigger the effect
 Signal.set(count, 100) // Nothing logged`}
     />
+    <div class="heading-anchor" id="effect-ignore">
+      <Typography text={static("Effect.ignore(disposer)")} variant={H3} />
+      <a class="anchor-link" href="#effect-ignore"> {"#"->Component.text} </a>
+    </div>
+    <Typography
+      text={static(
+        "Explicitly discards the disposer for fire-and-forget effects where you don't need to manually stop the effect.",
+      )}
+    />
+    <CodeBlock
+      language="rescript"
+      code={`// Fire-and-forget effect — disposer explicitly discarded
+Effect.run(() => {
+  Console.log(Signal.get(count))
+  None
+})->Effect.ignore`}
+    />
     <Separator />
     <div class="heading-anchor" id="common-use-cases">
       <Typography text={static("Common Use Cases")} variant={H2} />
@@ -119,7 +136,7 @@ Effect.run(() => {
   let el = Document.getElementById("title")
   el->Element.setTextContent(Signal.get(title))
   None
-})`}
+})->Effect.ignore`}
     />
     <div class="heading-anchor" id="event-listeners">
       <Typography text={static("Event Listeners")} variant={H3} />
@@ -137,7 +154,7 @@ Effect.run(() => {
   } else {
     None
   }
-})`}
+})->Effect.ignore`}
     />
     <div class="heading-anchor" id="timers">
       <Typography text={static("Timers")} variant={H3} />
@@ -151,7 +168,7 @@ Effect.run(() => {
   let ms = Signal.get(interval)
   let id = setInterval(() => Console.log("Tick!"), ms)
   Some(() => clearInterval(id))
-})`}
+})->Effect.ignore`}
     />
     <div class="heading-anchor" id="local-storage">
       <Typography text={static("Local Storage Sync")} variant={H3} />
@@ -165,7 +182,7 @@ Effect.run(() => {
   let current = Signal.get(theme)
   LocalStorage.setItem("theme", current)
   None
-})`}
+})->Effect.ignore`}
     />
     <EditOnGitHub pageName="Pages__ApiEffect" />
   </div>

--- a/docs-website/src/pages/Pages__GettingStarted.res
+++ b/docs-website/src/pages/Pages__GettingStarted.res
@@ -103,7 +103,8 @@ Computed.get(doubled) // 10`}
       code={`let count = Signal.make(0)
 Effect.run(() => {
   Console.log(\`Count changed to: \${Signal.get(count)->Int.toString}\`)
-})`}
+  None
+})->Effect.ignore`}
     />
     <EditOnGitHub pageName="Pages__GettingStarted" />
   </div>

--- a/src/signals/Signals__Effects.res
+++ b/src/signals/Signals__Effects.res
@@ -59,3 +59,5 @@ let run = (fn: unit => option<unit => unit>, ~name: option<string>=?): disposer 
 
   {dispose: dispose}
 }
+
+let ignore = (_: disposer): unit => ()


### PR DESCRIPTION
Following up #21, we're adding a typed `ignore` function to the `Effect` module. This allows users to explicitly discard the disposer when they don't need it.

Before:
```res
let _ = Effect.run(effectFn)
```

After:
```res
Effect.run(effectFn)->Effect.ignore
```

I also have another alternative with a breaking change in Effect.run on PR #23 