### PR TITLE
perf: version based tracking and link reuse

### DIFF
--- a/packages/rescript-signals/src/signals/Computed.res
+++ b/packages/rescript-signals/src/signals/Computed.res
@@ -1,18 +1,24 @@
-
-let make = (compute: unit => 'a, ~name: option<string>=?): Signal.t<'a> => {
+let makeWithoutEquals = (
+  compute: unit => 'a,
+  ~name: option<string>=?,
+): Signal.t<'a> => {
   let id = Id.make()
+  let equalsFn: ('a, 'a) => bool = (_a, _b) => false
 
   // Create a mutable ref to hold the signal so the compute function can update it
   // Using Obj.magic to avoid Option wrapper overhead
   let signalRef: ref<Signal.t<'a>> = ref(Obj.magic())
 
-  // Recompute function - updates the signal's value directly
+  // Fast recompute path for default behavior (no custom equality checks)
   let recompute = () => {
-    signalRef.contents.value = compute()
+    let currentSignal = signalRef.contents
+    let newValue = compute()
+    currentSignal.value = newValue
+    currentSignal.subs.version = currentSignal.subs.version + 1
   }
 
   // Create combined subs (this IS the observer for the computed)
-  let subs = Core.makeComputedSubs(recompute)
+  let subs = Core.makeComputedSubs(recompute, ~deferEffectsUntilRecompute=false)
 
   // Initial computation under tracking to establish dependencies
   let prev = Scheduler.currentComputedSubs.contents
@@ -24,17 +30,81 @@ let make = (compute: unit => 'a, ~name: option<string>=?): Signal.t<'a> => {
   let signal: Signal.t<'a> = {
     id,
     value: initialValue,
-    equals: (_, _) => false, // Computeds always check freshness via dirty flag
+    equals: equalsFn,
     name,
     subs,
   }
 
   // Set the ref so recompute can access the signal
   signalRef := signal
+  subs.lastGlobalVersion = Core.globalVersion.contents
   Core.clearSubsDirty(subs)
 
   signal
 }
+
+let makeWithEquals = (
+  compute: unit => 'a,
+  equalsFn: ('a, 'a) => bool,
+  ~name: option<string>=?,
+): Signal.t<'a> => {
+  let id = Id.make()
+
+  // Create a mutable ref to hold the signal so the compute function can update it
+  // Using Obj.magic to avoid Option wrapper overhead
+  let signalRef: ref<Signal.t<'a>> = ref(Obj.magic())
+
+  // Recompute function - updates the signal's value and tracks if it changed
+  let recompute = () => {
+    let currentSignal = signalRef.contents
+    let previousValue = currentSignal.value
+    let newValue = compute()
+    let shouldUpdate = try {
+      !currentSignal.equals(previousValue, newValue)
+    } catch {
+    | _ => true
+    }
+    if shouldUpdate {
+      currentSignal.value = newValue
+      currentSignal.subs.version = currentSignal.subs.version + 1
+    }
+  }
+
+  // Create combined subs (this IS the observer for the computed)
+  let subs = Core.makeComputedSubs(recompute, ~deferEffectsUntilRecompute=true)
+
+  // Initial computation under tracking to establish dependencies
+  let prev = Scheduler.currentComputedSubs.contents
+  Scheduler.currentComputedSubs := Some(subs)
+  let initialValue = compute()
+  Scheduler.currentComputedSubs := prev
+
+  // Create the signal with the initial value
+  let signal: Signal.t<'a> = {
+    id,
+    value: initialValue,
+    equals: equalsFn,
+    name,
+    subs,
+  }
+
+  // Set the ref so recompute can access the signal
+  signalRef := signal
+  subs.lastGlobalVersion = Core.globalVersion.contents
+  Core.clearSubsDirty(subs)
+
+  signal
+}
+
+let make = (
+  compute: unit => 'a,
+  ~name: option<string>=?,
+  ~equals: option<('a, 'a) => bool>=?,
+): Signal.t<'a> =>
+  switch equals {
+  | Some(eq) => makeWithEquals(compute, eq, ~name?)
+  | None => makeWithoutEquals(compute, ~name?)
+  }
 
 let dispose = (signal: Signal.t<'a>): unit => {
   Core.clearSubsDeps(signal.subs)

--- a/packages/rescript-signals/src/signals/Core.res
+++ b/packages/rescript-signals/src/signals/Core.res
@@ -6,74 +6,99 @@ let flag_dirty = 1
 let flag_pending = 2
 let flag_running = 4
 
-// Observer kind tag
+// Global tracking version
+let trackingVersion: ref<int> = ref(0)
+// Global mutation version (increments on real signal writes)
+let globalVersion: ref<int> = ref(0)
+
 type kind = [#Effect | #Computed]
 
-// Forward declare mutually recursive types
-type rec link = {
-  // Direct reference to signal's subscriber list (type-erased)
-  mutable subs: subs,
-  // Direct reference to observer
-  mutable observer: observer,
-  // Links in the observer's dependency chain
-  mutable nextDep: option<link>,
-  mutable prevDep: option<link>,
-  // Links in the signal's subscriber chain
-  mutable nextSub: option<link>,
-  mutable prevSub: option<link>,
-}
+module rec Link: {
+  type t = {
+    // Direct reference to signal's subscriber list (type-erased)
+    mutable subs: Subs.t,
+    // Direct reference to observer
+    mutable observer: Observer.t,
+    // Links in the observer's dependency chain
+    mutable nextDep: option<Link.t>,
+    mutable prevDep: option<Link.t>,
+    // Links in the signal's subscriber chain
+    mutable nextSub: option<Link.t>,
+    mutable prevSub: option<Link.t>,
+    // Version stamp for duplicate detection within a compute cycle
+    mutable lastTrackedVersion: int,
+  }
+} = Link
 
 // Signal subscriber list (head/tail of linked list)
 // For computeds, this same object also serves as the observer (combined structure)
-and subs = {
-  mutable first: option<link>,
-  mutable last: option<link>,
-  mutable version: int,
-  // === Observer fields (only used for computeds) ===
-  // If compute is Some, this subs is a computed signal
-  mutable compute: option<unit => unit>,
-  mutable firstDep: option<link>,
-  mutable lastDep: option<link>,
-  mutable flags: int,
-  mutable level: int,
-}
+and Subs: {
+  type t = {
+    mutable first: option<Link.t>,
+    mutable last: option<Link.t>,
+    mutable computedSubscriberCount: int,
+    mutable version: int,
+    // === Observer fields (only used for computeds) ===
+    // If compute is Some, this subs is a computed signal
+    mutable compute: option<unit => unit>,
+    mutable firstDep: option<Link.t>,
+    mutable lastDep: option<Link.t>,
+    mutable flags: int,
+    mutable level: int,
+    mutable deferEffectsUntilRecompute: bool,
+    mutable lastGlobalVersion: int,
+  }
+} = Subs
 
 // Observer for effects only (computeds use subs directly)
-and observer = {
-  id: int,
-  kind: kind,
-  run: unit => unit,
-  mutable firstDep: option<link>,
-  mutable lastDep: option<link>,
-  mutable flags: int,
-  mutable level: int,
-  name: option<string>,
-  // For computed observers: direct reference to backing subs (the combined object)
-  mutable backingSubs: option<subs>,
-}
+and Observer: {
+  type t = {
+    id: int,
+    kind: kind,
+    run: unit => unit,
+    mutable firstDep: option<Link.t>,
+    mutable lastDep: option<Link.t>,
+    mutable flags: int,
+    mutable level: int,
+    name: option<string>,
+    // For computed observers: direct reference to backing subs (the combined object)
+    mutable backingSubs: option<Subs.t>,
+  }
+} = Observer
+
+// Type aliases for convenience
+type link = Link.t
+type subs = Subs.t
+type observer = Observer.t
 
 // Create empty subscriber list (for plain signals)
 let makeSubs = (): subs => {
   first: None,
   last: None,
+  computedSubscriberCount: 0,
   version: 0,
   compute: None,
   firstDep: None,
   lastDep: None,
   flags: 0,
   level: 0,
+  deferEffectsUntilRecompute: false,
+  lastGlobalVersion: 0,
 }
 
 // Create subs for a computed (with compute function)
-let makeComputedSubs = (compute: unit => unit): subs => {
+let makeComputedSubs = (compute: unit => unit, ~deferEffectsUntilRecompute: bool=false): subs => {
   first: None,
   last: None,
+  computedSubscriberCount: 0,
   version: 0,
   compute: Some(compute),
   firstDep: None,
   lastDep: None,
   flags: flag_dirty, // start dirty
   level: 0,
+  deferEffectsUntilRecompute,
+  lastGlobalVersion: 0,
 }
 
 // Create observer
@@ -95,7 +120,7 @@ let makeObserver = (
   backingSubs,
 }
 
-// Flag operations for observer (using Int.Bitwise module)
+// Flag operations for observer
 let isDirty = (o: observer): bool => Int.bitwiseAnd(o.flags, flag_dirty) !== 0
 let setDirty = (o: observer): unit => o.flags = Int.bitwiseOr(o.flags, flag_dirty)
 let clearDirty = (o: observer): unit =>
@@ -105,7 +130,7 @@ let setPending = (o: observer): unit => o.flags = Int.bitwiseOr(o.flags, flag_pe
 let clearPending = (o: observer): unit =>
   o.flags = Int.bitwiseAnd(o.flags, Int.bitwiseNot(flag_pending))
 
-// Flag operations for subs (for computeds - subs IS the observer)
+// Flag operations for subs
 let isSubsDirty = (s: subs): bool => Int.bitwiseAnd(s.flags, flag_dirty) !== 0
 let setSubsDirty = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_dirty)
 let clearSubsDirty = (s: subs): unit =>
@@ -115,17 +140,20 @@ let setSubsPending = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_pe
 let clearSubsPending = (s: subs): unit =>
   s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_pending))
 
-// Check if subs is a computed (has compute function)
+// Check if subs is a computed
 let isComputed = (s: subs): bool => s.compute !== None
 
 // Create a link node
-let makeLink = (subs: subs, observer: observer): link => {
-  subs,
-  observer,
-  nextDep: None,
-  prevDep: None,
-  nextSub: None,
-  prevSub: None,
+let makeLink = (sourceSubs: subs, linkedObserver: observer): link => {
+  {
+    subs: sourceSubs,
+    observer: linkedObserver,
+    nextDep: None,
+    prevDep: None,
+    nextSub: None,
+    prevSub: None,
+    lastTrackedVersion: 0,
+  }
 }
 
 // Add link to signal's subscriber list
@@ -137,6 +165,11 @@ let linkToSubs = (subs: subs, link: link): unit => {
   | None => subs.first = Some(link)
   }
   subs.last = Some(link)
+
+  let linkedSubs = (Obj.magic(link.observer): subs)
+  if isComputed(linkedSubs) {
+    subs.computedSubscriberCount = subs.computedSubscriberCount + 1
+  }
 }
 
 // Add link to observer's dependency list
@@ -163,6 +196,11 @@ let unlinkFromSubs = (link: link): unit => {
   }
   link.prevSub = None
   link.nextSub = None
+
+  let linkedSubs = (Obj.magic(link.observer): subs)
+  if isComputed(linkedSubs) && subs.computedSubscriberCount > 0 {
+    subs.computedSubscriberCount = subs.computedSubscriberCount - 1
+  }
 }
 
 // Remove link from dependency list
@@ -174,6 +212,20 @@ let unlinkFromDeps = (observer: observer, link: link): unit => {
   switch link.nextDep {
   | Some(next) => next.prevDep = link.prevDep
   | None => observer.lastDep = link.prevDep
+  }
+  link.prevDep = None
+  link.nextDep = None
+}
+
+// Remove link from subs's dependency list (for computeds - subs IS the observer)
+let unlinkFromSubsDeps = (s: subs, link: link): unit => {
+  switch link.prevDep {
+  | Some(prev) => prev.nextDep = link.nextDep
+  | None => s.firstDep = link.nextDep
+  }
+  switch link.nextDep {
+  | Some(next) => next.prevDep = link.prevDep
+  | None => s.lastDep = link.prevDep
   }
   link.prevDep = None
   link.nextDep = None

--- a/packages/rescript-signals/src/signals/Scheduler.res
+++ b/packages/rescript-signals/src/signals/Scheduler.res
@@ -4,102 +4,220 @@ let currentComputedSubs: ref<option<Core.subs>> = ref(None)
 // Current execution context for effects
 let currentObserver: ref<option<Core.observer>> = ref(None)
 
+// Current dependency tracking version (shared across nested compute/effect runs)
+let currentTrackingVersion: ref<int> = ref(0)
+
+// Per-run dependency cursors (separate from true tail pointers).
+let currentComputedDepCursor: ref<option<Core.link>> = ref(None)
+let currentObserverDepCursor: ref<option<Core.link>> = ref(None)
+
 // Pending effects to execute
 let pendingEffects: array<Core.observer> = []
 // Pending computeds to recompute (subs that are dirty)
 let pendingComputedSubs: array<Core.subs> = []
 let flushing: ref<bool> = ref(false)
+let pendingEffectsNeedsSort: ref<bool> = ref(false)
+let pendingComputedNeedsSort: ref<bool> = ref(false)
+let lastEnqueuedEffectLevel: ref<int> = ref(0)
+let lastEnqueuedComputedLevel: ref<int> = ref(0)
 
 // Queue for iterative dirty marking
 let dirtyQueue: array<Core.subs> = []
 
 // Efficient array clear
 let clearArray: array<'a> => unit = %raw(`function(arr) { arr.length = 0 }`)
+let drainProcessedPrefix: (array<'a>, int) => unit = %raw(`
+function(arr, processedCount) {
+  if (processedCount <= 0) return;
+  if (processedCount >= arr.length) {
+    arr.length = 0;
+    return;
+  }
+  arr.copyWithin(0, processedCount);
+  arr.length = arr.length - processedCount;
+}
+`)
 
 // Add effect to pending if not already there
 let addEffectToPending = (observer: Core.observer): unit => {
   if !Core.isPending(observer) {
     Core.setPending(observer)
+    let lengthBefore = pendingEffects->Array.length
+    if lengthBefore == 0 {
+      pendingEffectsNeedsSort := false
+    } else if observer.level < lastEnqueuedEffectLevel.contents {
+      pendingEffectsNeedsSort := true
+    }
     pendingEffects->Array.push(observer)->ignore
+    lastEnqueuedEffectLevel := observer.level
+  }
+}
+
+// Add computed to pending if not already there
+let addComputedToPending = (subs: Core.subs): unit => {
+  if !Core.isSubsPending(subs) {
+    Core.setSubsPending(subs)
+    let lengthBefore = pendingComputedSubs->Array.length
+    if lengthBefore == 0 {
+      pendingComputedNeedsSort := false
+    } else if subs.level < lastEnqueuedComputedLevel.contents {
+      pendingComputedNeedsSort := true
+    }
+    pendingComputedSubs->Array.push(subs)->ignore
+    lastEnqueuedComputedLevel := subs.level
   }
 }
 
 // Track a dependency from a computed (subs tracks subs)
-// For initial computation (firstDep is None), skip duplicate check since deps are empty
 let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): unit => {
-  // Fast path: if no deps yet, no need to check for duplicates
+  let computedObserver: Core.observer = Obj.magic(computedSubs)
+
   if computedSubs.firstDep === None {
-    let newLink: Core.link = {
-      subs: sourceSubs,
-      observer: Obj.magic(computedSubs),
-      nextDep: None,
-      prevDep: None,
-      nextSub: None,
-      prevSub: None,
-    }
+    let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
+    newLink.lastTrackedVersion = currentTrackingVersion.contents
     Core.linkToSubsDeps(computedSubs, newLink)
     Core.linkToSubs(sourceSubs, newLink)
+    currentComputedDepCursor := Some(newLink)
   } else {
-    // Check if already tracking this signal (walk dep list)
-    let found = ref(false)
-    let link = ref(computedSubs.firstDep)
-    while link.contents !== None && !found.contents {
-      switch link.contents {
-      | Some(l) =>
-        if l.subs === sourceSubs {
-          found := true
-        } else {
-          link := l.nextDep
+    let currentVersion = currentTrackingVersion.contents
+    // Fast path: reuse run cursor or cursor.next to avoid scanning in common cases.
+    let fastPathFound = ref(false)
+    switch currentComputedDepCursor.contents {
+    | Some(cursor) =>
+      if cursor.subs === sourceSubs && cursor.observer === computedObserver {
+        cursor.lastTrackedVersion = currentVersion
+        fastPathFound.contents = true
+      } else {
+        switch cursor.nextDep {
+        | Some(nextDep) =>
+          if nextDep.subs === sourceSubs && nextDep.observer === computedObserver {
+            nextDep.lastTrackedVersion = currentVersion
+            currentComputedDepCursor := Some(nextDep)
+            fastPathFound.contents = true
+          }
+        | None => ()
+        }
+      }
+    | None => ()
+    }
+
+    if !fastPathFound.contents {
+      switch sourceSubs.last {
+      | Some(lastSubLink) =>
+        if lastSubLink.lastTrackedVersion === currentVersion && lastSubLink.observer === computedObserver {
+          lastSubLink.lastTrackedVersion = currentVersion
+          currentComputedDepCursor := Some(lastSubLink)
+          fastPathFound.contents = true
         }
       | None => ()
       }
     }
 
-    // Only add if not already tracked
-    if !found.contents {
-      let newLink: Core.link = {
-        subs: sourceSubs,
-        observer: Obj.magic(computedSubs),
-        nextDep: None,
-        prevDep: None,
-        nextSub: None,
-        prevSub: None,
+    if !fastPathFound.contents {
+      // Fall back to full scan
+      let found = ref(false)
+      let foundLink: ref<option<Core.link>> = ref(None)
+      let link = ref(computedSubs.firstDep)
+      while link.contents !== None && !found.contents {
+        switch link.contents {
+        | Some(l) =>
+          if l.subs === sourceSubs {
+            l.lastTrackedVersion = currentVersion
+            foundLink := Some(l)
+            found := true
+          } else {
+            link := l.nextDep
+          }
+        | None => ()
+        }
       }
-      Core.linkToSubsDeps(computedSubs, newLink)
-      Core.linkToSubs(sourceSubs, newLink)
+
+      // Create new link only if not found
+      if !found.contents {
+        let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
+        newLink.lastTrackedVersion = currentVersion
+        Core.linkToSubsDeps(computedSubs, newLink)
+        Core.linkToSubs(sourceSubs, newLink)
+        currentComputedDepCursor := Some(newLink)
+      } else {
+        currentComputedDepCursor := foundLink.contents
+      }
     }
   }
 }
 
 // Track a dependency from an effect (observer tracks subs)
-// For initial run (firstDep is None), skip duplicate check since deps are empty
-let trackDepFromEffect = (observer: Core.observer, subs: Core.subs): unit => {
-  // Fast path: if no deps yet, no need to check for duplicates
+// Uses version-based duplicate detection within a run cycle
+let trackDepFromEffect = (observer: Core.observer, sourceSubs: Core.subs): unit => {
   if observer.firstDep === None {
-    let newLink = Core.makeLink(subs, observer)
+    let newLink: Core.link = Core.makeLink(sourceSubs, observer)
+    newLink.lastTrackedVersion = currentTrackingVersion.contents
     Core.linkToDeps(observer, newLink)
-    Core.linkToSubs(subs, newLink)
+    Core.linkToSubs(sourceSubs, newLink)
+    currentObserverDepCursor := Some(newLink)
   } else {
-    // Check if already tracking this signal (walk dep list)
-    let found = ref(false)
-    let link = ref(observer.firstDep)
-    while link.contents !== None && !found.contents {
-      switch link.contents {
-      | Some(l) =>
-        if l.subs === subs {
-          found := true
-        } else {
-          link := l.nextDep
+    let currentVersion = currentTrackingVersion.contents
+    // Fast path: reuse run cursor or cursor.next to avoid scanning in common cases.
+    let fastPathFound = ref(false)
+    switch currentObserverDepCursor.contents {
+    | Some(cursor) =>
+      if cursor.subs === sourceSubs && cursor.observer === observer {
+        cursor.lastTrackedVersion = currentVersion
+        fastPathFound.contents = true
+      } else {
+        switch cursor.nextDep {
+        | Some(nextDep) =>
+          if nextDep.subs === sourceSubs && nextDep.observer === observer {
+            nextDep.lastTrackedVersion = currentVersion
+            currentObserverDepCursor := Some(nextDep)
+            fastPathFound.contents = true
+          }
+        | None => ()
+        }
+      }
+    | None => ()
+    }
+
+    if !fastPathFound.contents {
+      switch sourceSubs.last {
+      | Some(lastSubLink) =>
+        if lastSubLink.lastTrackedVersion === currentVersion && lastSubLink.observer === observer {
+          lastSubLink.lastTrackedVersion = currentVersion
+          currentObserverDepCursor := Some(lastSubLink)
+          fastPathFound.contents = true
         }
       | None => ()
       }
     }
 
-    // Only add if not already tracked
-    if !found.contents {
-      let newLink = Core.makeLink(subs, observer)
-      Core.linkToDeps(observer, newLink)
-      Core.linkToSubs(subs, newLink)
+    if !fastPathFound.contents {
+      let found = ref(false)
+      let foundLink: ref<option<Core.link>> = ref(None)
+      let link = ref(observer.firstDep)
+      while link.contents !== None && !found.contents {
+        switch link.contents {
+        | Some(l) =>
+          if l.subs === sourceSubs {
+            l.lastTrackedVersion = currentVersion
+            foundLink := Some(l)
+            found := true
+          } else {
+            link := l.nextDep
+          }
+        | None => ()
+        }
+      }
+
+      // Create new link only if not found
+      if !found.contents {
+        let newLink: Core.link = Core.makeLink(sourceSubs, observer)
+        newLink.lastTrackedVersion = currentVersion
+        Core.linkToDeps(observer, newLink)
+        Core.linkToSubs(sourceSubs, newLink)
+        currentObserverDepCursor := Some(newLink)
+      } else {
+        currentObserverDepCursor := foundLink.contents
+      }
     }
   }
 }
@@ -146,7 +264,7 @@ let computeSubsLevel = (s: Core.subs): int => {
 }
 
 // Compute level for an effect
-let rec computeLevel = (observer: Core.observer): int => {
+let computeLevel = (observer: Core.observer): int => {
   let maxLevel = ref(0)
   let link = ref(observer.firstDep)
   while link.contents !== None {
@@ -164,51 +282,143 @@ let rec computeLevel = (observer: Core.observer): int => {
   maxLevel.contents + 1
 }
 
-// Retrack a computed (recompute and rebuild deps)
-and retrackComputed = (s: Core.subs): unit => {
-  let oldLevel = s.level
+// Run one computed recompute cycle with link reuse.
+let runComputedCycle = (subs: Core.subs, ~clearPending: bool): unit => {
+  let previousTrackingVersion = currentTrackingVersion.contents
+  let previousVersion = subs.version
 
-  Core.clearSubsDeps(s)
-  Core.clearSubsPending(s)
+  // Increment tracking version for this cycle
+  Core.trackingVersion := Core.trackingVersion.contents + 1
+  currentTrackingVersion.contents = Core.trackingVersion.contents
+
+  // DON'T clear deps - we'll reuse existing links
+  if clearPending {
+    Core.clearSubsPending(subs)
+  }
 
   let prev = currentComputedSubs.contents
-  currentComputedSubs := Some(s)
+  let prevCursor = currentComputedDepCursor.contents
+  currentComputedSubs := Some(subs)
+  currentComputedDepCursor := subs.firstDep
 
   try {
-    switch s.compute {
+    switch subs.compute {
     | Some(compute) => compute()
     | None => ()
     }
-    Core.clearSubsDirty(s)
+
+    // After compute: unlink stale deps (version != current)
+    let link = ref(subs.firstDep)
+    while link.contents !== None {
+      switch link.contents {
+      | Some(l) =>
+        let next = l.nextDep
+        if l.lastTrackedVersion !== currentTrackingVersion.contents {
+          // Stale - unlink from source's subscriber list and our dep list
+          Core.unlinkFromSubs(l)
+          Core.unlinkFromSubsDeps(subs, l)
+        }
+        link := next
+      | None => ()
+      }
+    }
+
+    Core.clearSubsDirty(subs)
+    subs.lastGlobalVersion = Core.globalVersion.contents
+
+    // Propagate only when computed output changed.
+    if subs.first !== None && subs.version !== previousVersion {
+      let subLink = ref(subs.first)
+      while subLink.contents !== None {
+        switch subLink.contents {
+        | Some(l) =>
+          let linkedSubs = (Obj.magic(l.observer): Core.subs)
+          if Core.isComputed(linkedSubs) {
+            // Mark downstream computed dirty (lazy propagation).
+            Core.setSubsDirty(linkedSubs)
+          } else {
+            // Effects get queued for execution unless this effect is already running.
+            switch currentObserver.contents {
+            | Some(currentObserver) =>
+              if currentObserver !== l.observer {
+                addEffectToPending(l.observer)
+              }
+            | None => addEffectToPending(l.observer)
+            }
+          }
+          subLink := l.nextSub
+        | None => ()
+        }
+      }
+    }
+
     currentComputedSubs := prev
+    currentComputedDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
   } catch {
   | exn =>
     currentComputedSubs := prev
+    currentComputedDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
     throw(exn)
   }
+}
+
+// Retrack a computed (recompute with link reuse)
+let retrackComputed = (s: Core.subs): unit => {
+  let oldLevel = s.level
+  runComputedCycle(s, ~clearPending=true)
 
   if oldLevel == 0 {
     s.level = computeSubsLevel(s)
   }
 }
 
-// Retrack an effect
-and retrackEffect = (observer: Core.observer): unit => {
+// Retrack an effect (with link reuse)
+let retrackEffect = (observer: Core.observer): unit => {
   let oldLevel = observer.level
+  let previousTrackingVersion = currentTrackingVersion.contents
 
-  Core.clearDeps(observer)
+  // Increment tracking version for this cycle
+  Core.trackingVersion := Core.trackingVersion.contents + 1
+  currentTrackingVersion.contents = Core.trackingVersion.contents
+
+  // DON'T clear deps - we'll reuse existing links
   Core.clearPending(observer)
 
   let prev = currentObserver.contents
+  let prevCursor = currentObserverDepCursor.contents
   currentObserver := Some(observer)
+  currentObserverDepCursor := observer.firstDep
 
   try {
     observer.run()
+
+    // After run: unlink stale deps (version != current)
+    let link = ref(observer.firstDep)
+    while link.contents !== None {
+      switch link.contents {
+      | Some(l) =>
+        let next = l.nextDep
+        if l.lastTrackedVersion !== currentTrackingVersion.contents {
+          // Stale - unlink from source's subscriber list and our dep list
+          Core.unlinkFromSubs(l)
+          Core.unlinkFromDeps(observer, l)
+        }
+        link := next
+      | None => ()
+      }
+    }
+
     Core.clearDirty(observer)
     currentObserver := prev
+    currentObserverDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
   } catch {
   | exn =>
     currentObserver := prev
+    currentObserverDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
     throw(exn)
   }
 
@@ -218,26 +428,52 @@ and retrackEffect = (observer: Core.observer): unit => {
 }
 
 // Flush pending observers
-and flush = (): unit => {
+let flush = (): unit => {
   flushing := true
 
   try {
     while pendingEffects->Array.length > 0 || pendingComputedSubs->Array.length > 0 {
       // Process computeds first (they might trigger more effects)
       if pendingComputedSubs->Array.length > 0 {
-        // Sort by level
-        pendingComputedSubs->Array.sort(compareSubsByLevel)->ignore
-        let computeds = pendingComputedSubs->Array.copy
-        clearArray(pendingComputedSubs)
-        computeds->Array.forEach(retrackComputed)
+        let computedsLength = pendingComputedSubs->Array.length
+        if computedsLength > 1 && pendingComputedNeedsSort.contents {
+          // Sort by level
+          pendingComputedSubs->Array.sort(compareSubsByLevel)->ignore
+          pendingComputedNeedsSort := false
+        }
+        let i = ref(0)
+        while i.contents < computedsLength {
+          switch pendingComputedSubs->Array.get(i.contents) {
+          | Some(subs) => retrackComputed(subs)
+          | None => ()
+          }
+          i := i.contents + 1
+        }
+        drainProcessedPrefix(pendingComputedSubs, computedsLength)
+        if pendingComputedSubs->Array.length == 0 {
+          pendingComputedNeedsSort := false
+        }
       }
 
       // Then process effects
       if pendingEffects->Array.length > 0 {
-        pendingEffects->Array.sort(compareEffectsByLevel)->ignore
-        let effects = pendingEffects->Array.copy
-        clearArray(pendingEffects)
-        effects->Array.forEach(retrackEffect)
+        let effectsLength = pendingEffects->Array.length
+        if effectsLength > 1 && pendingEffectsNeedsSort.contents {
+          pendingEffects->Array.sort(compareEffectsByLevel)->ignore
+          pendingEffectsNeedsSort := false
+        }
+        let i = ref(0)
+        while i.contents < effectsLength {
+          switch pendingEffects->Array.get(i.contents) {
+          | Some(effect) => retrackEffect(effect)
+          | None => ()
+          }
+          i := i.contents + 1
+        }
+        drainProcessedPrefix(pendingEffects, effectsLength)
+        if pendingEffects->Array.length == 0 {
+          pendingEffectsNeedsSort := false
+        }
       }
     }
 
@@ -250,37 +486,67 @@ and flush = (): unit => {
 }
 
 // Notify all subscribers of a signal (traverse linked list)
+// Marks computeds dirty transitively.
+// Direct effects are queued immediately.
+// Effects reached through dirty computeds are deferred until parent computed recompute.
 let notifySubs = (subs: Core.subs): unit => {
-  dirtyQueue->Array.push(subs)->ignore
+  // Fast path: no subscribers, nothing to notify.
+  if subs.first === None {
+    ()
+  } else if !Core.isComputed(subs) && subs.computedSubscriberCount == 0 {
+    // Fast path for plain signals with direct effect subscribers only.
+    let link = ref(subs.first)
+    while link.contents !== None {
+      switch link.contents {
+      | Some(l) =>
+        addEffectToPending(l.observer)
+        link := l.nextSub
+      | None => ()
+      }
+    }
+  } else {
+    dirtyQueue->Array.push(subs)->ignore
 
-  while dirtyQueue->Array.length > 0 {
-    let currentSubs = dirtyQueue->Array.pop
-    switch currentSubs {
-    | None => ()
-    | Some(s) =>
-      let link = ref(s.first)
-      while link.contents !== None {
-        switch link.contents {
-        | Some(l) =>
-          // The observer field might be a real observer (effect) or a subs (computed)
-          // We detect by checking if the subs the link came FROM is a computed
-          let linkedSubs = (Obj.magic(l.observer): Core.subs)
-          if Core.isComputed(linkedSubs) {
-            // It's a computed - mark dirty and propagate
-            if !Core.isSubsDirty(linkedSubs) {
-              Core.setSubsDirty(linkedSubs)
-              dirtyQueue->Array.push(linkedSubs)->ignore
+    let i = ref(0)
+    while i.contents < dirtyQueue->Array.length {
+      let currentSubs = dirtyQueue->Array.get(i.contents)
+      i := i.contents + 1
+      switch currentSubs {
+      | None => ()
+      | Some(s) =>
+        let link = ref(s.first)
+        while link.contents !== None {
+          switch link.contents {
+          | Some(l) =>
+            // The observer field might be a real observer (effect) or a subs (computed)
+            let linkedSubs = (Obj.magic(l.observer): Core.subs)
+            if Core.isComputed(linkedSubs) {
+              // It's a computed - mark dirty and propagate transitively
+              if !Core.isSubsDirty(linkedSubs) {
+                Core.setSubsDirty(linkedSubs)
+                dirtyQueue->Array.push(linkedSubs)->ignore
+              }
+            } else {
+              // It's an effect.
+              // If reached via a dirty computed, defer effect until computed recompute.
+              // This lets computed equality short-circuit downstream effect runs.
+              if Core.isComputed(s) {
+                if s.deferEffectsUntilRecompute {
+                  addComputedToPending(s)
+                } else {
+                  addEffectToPending(l.observer)
+                }
+              } else {
+                addEffectToPending(l.observer)
+              }
             }
-          } else {
-            // It's an effect
-            let observer = l.observer
-            addEffectToPending(observer)
+            link := l.nextSub
+          | None => ()
           }
-          link := l.nextSub
-        | None => ()
         }
       }
     }
+    clearArray(dirtyQueue)
   }
 
   if (pendingEffects->Array.length > 0 || pendingComputedSubs->Array.length > 0) && !flushing.contents {
@@ -288,31 +554,21 @@ let notifySubs = (subs: Core.subs): unit => {
   }
 }
 
-// Ensure a computed signal is fresh before reading
+// Ensure a computed signal is fresh before reading (with link reuse)
 let ensureComputedFresh = (subs: Core.subs): unit => {
-  if Core.isComputed(subs) && Core.isSubsDirty(subs) {
-    let oldLevel = subs.level
+  if Core.isComputed(subs) {
+    if Core.isSubsDirty(subs) {
+      // Dirty without a newer global write means stale dirty flag only.
+      if subs.lastGlobalVersion === Core.globalVersion.contents {
+        Core.clearSubsDirty(subs)
+      } else {
+        let oldLevel = subs.level
+        runComputedCycle(subs, ~clearPending=false)
 
-    Core.clearSubsDeps(subs)
-
-    let prev = currentComputedSubs.contents
-    currentComputedSubs := Some(subs)
-
-    try {
-      switch subs.compute {
-      | Some(compute) => compute()
-      | None => ()
+        if oldLevel == 0 {
+          subs.level = computeSubsLevel(subs)
+        }
       }
-      Core.clearSubsDirty(subs)
-      currentComputedSubs := prev
-    } catch {
-    | exn =>
-      currentComputedSubs := prev
-      throw(exn)
-    }
-
-    if oldLevel == 0 {
-      subs.level = computeSubsLevel(subs)
     }
   }
 }
@@ -352,17 +608,25 @@ let batch = fn => {
 let untrack = (fn: unit => 'a): 'a => {
   let prevComputed = currentComputedSubs.contents
   let prevObserver = currentObserver.contents
+  let prevComputedCursor = currentComputedDepCursor.contents
+  let prevObserverCursor = currentObserverDepCursor.contents
   currentComputedSubs := None
   currentObserver := None
+  currentComputedDepCursor := None
+  currentObserverDepCursor := None
   try {
     let result = fn()
     currentComputedSubs := prevComputed
     currentObserver := prevObserver
+    currentComputedDepCursor := prevComputedCursor
+    currentObserverDepCursor := prevObserverCursor
     result
   } catch {
   | exn =>
     currentComputedSubs := prevComputed
     currentObserver := prevObserver
+    currentComputedDepCursor := prevComputedCursor
+    currentObserverDepCursor := prevObserverCursor
     throw(exn)
   }
 }

--- a/packages/rescript-signals/src/signals/Signal.res
+++ b/packages/rescript-signals/src/signals/Signal.res
@@ -7,15 +7,22 @@ type t<'a> = {
   subs: Core.subs,
 }
 
+let defaultEquals = (a: 'a, b: 'a): bool => a === b
+let neverEquals: ('a, 'a) => bool = (_a, _b) => false
+
 let make = (initialValue: 'a, ~name: option<string>=?, ~equals: option<('a, 'a) => bool>=?): t<
   'a,
 > => {
   let id = Id.make()
+  let equalsFn = switch equals {
+  | Some(eq) => eq
+  | None => defaultEquals
+  }
 
   {
     id,
     value: initialValue,
-    equals: equals->Option.getOr((a, b) => a === b),
+    equals: equalsFn,
     name,
     subs: Core.makeSubs(),
   }
@@ -27,7 +34,7 @@ let makeForComputed = (initialValue: 'a, ~name: option<string>=?): t<'a> => {
   {
     id,
     value: initialValue,
-    equals: (_, _) => false, // Computeds always check freshness via dirty flag
+    equals: neverEquals, // Computeds always check freshness via dirty flag
     name,
     subs: Core.makeSubs(),
   }
@@ -59,6 +66,7 @@ let set = (signal: t<'a>, newValue: 'a): unit => {
   if shouldUpdate {
     signal.value = newValue
     signal.subs.version = signal.subs.version + 1
+    Core.globalVersion := Core.globalVersion.contents + 1
     Scheduler.notifySubs(signal.subs)
   }
 }

--- a/packages/rescript-signals/tests/ComputedTests.res
+++ b/packages/rescript-signals/tests/ComputedTests.res
@@ -156,5 +156,203 @@ let tests = Suite.make(
       disposer.dispose()
       Assert.combineResults([result1, result2])
     }),
+    Test.make("computed with custom equals function", () => {
+      // Test that custom equals function is used for value comparison
+      let obj = Signal.make({"id": 1, "name": "Alice"})
+
+      // Computed extracts just the id, with custom equality
+      let userId = Computed.make(
+        () => Signal.get(obj)["id"],
+        ~equals=(a, b) => a == b,
+      )
+
+      let result1 = Assert.equal(Signal.peek(userId), 1, ~message="Initial value should be 1")
+
+      // Change name but keep same id
+      Signal.set(obj, {"id": 1, "name": "Bob"})
+      let result2 = Assert.equal(Signal.peek(userId), 1, ~message="Value should still be 1")
+
+      // Change id
+      Signal.set(obj, {"id": 2, "name": "Bob"})
+      let result3 = Assert.equal(Signal.peek(userId), 2, ~message="Value should update to 2")
+
+      Assert.combineResults([result1, result2, result3])
+    }),
+    Test.make("custom equals suppresses downstream effect when value is unchanged", () => {
+      let profile = Signal.make({"id": 1, "name": "Alice"})
+      let userId = Computed.make(
+        () => Signal.get(profile)["id"],
+        ~equals=(a, b) => a == b,
+      )
+      let effectRuns = ref(0)
+      let disposer = Effect.runWithDisposer(() => {
+        effectRuns := effectRuns.contents + 1
+        ignore(Signal.get(userId))
+        None
+      })
+
+      let result1 = Assert.equal(effectRuns.contents, 1, ~message="Effect should run once initially")
+
+      // Name changes, derived id does not.
+      Signal.set(profile, {"id": 1, "name": "Bob"})
+      let result2 = Assert.equal(
+        effectRuns.contents,
+        1,
+        ~message="Effect should not run when derived value is unchanged",
+      )
+
+      // Derived id changes.
+      Signal.set(profile, {"id": 2, "name": "Bob"})
+      let result3 = Assert.equal(
+        effectRuns.contents,
+        2,
+        ~message="Effect should run once when derived value changes",
+      )
+
+      disposer.dispose()
+      Assert.combineResults([result1, result2, result3])
+    }),
+    Test.make("repro: custom equals should suppress effect when derived value is unchanged", () => {
+      let profile = Signal.make({"id": 1, "name": "Alice"})
+      let userId = Computed.make(
+        () => Signal.get(profile)["id"],
+        ~equals=(a, b) => a == b,
+      )
+      let effectRuns = ref(0)
+      let disposer = Effect.runWithDisposer(() => {
+        effectRuns := effectRuns.contents + 1
+        ignore(Signal.get(userId))
+        None
+      })
+
+      // Source update does not change computed output.
+      Signal.set(profile, {"id": 1, "name": "Bob"})
+
+      let result = Assert.equal(
+        effectRuns.contents,
+        1,
+        ~message="Expected no effect re-run when custom equals says computed output is unchanged",
+      )
+
+      disposer.dispose()
+      result
+    }),
+    Test.make("computed equality with array length", () => {
+      let items = Signal.make([1, 2, 3])
+      let recomputeCount = ref(0)
+
+      // Computed that only cares about length, not contents
+      let length = Computed.make(
+        () => {
+          recomputeCount := recomputeCount.contents + 1
+          Signal.get(items)->Array.length
+        },
+        ~equals=(a, b) => a == b,
+      )
+
+      let _ = Signal.peek(length)
+      let result1 = Assert.equal(Signal.peek(length), 3, ~message="Initial length should be 3")
+
+      // Change contents but keep same length
+      Signal.set(items, [4, 5, 6])
+      let _ = Signal.peek(length)
+      let result2 = Assert.equal(Signal.peek(length), 3, ~message="Length should still be 3")
+
+      // Change length
+      Signal.set(items, [1, 2])
+      let result3 = Assert.equal(Signal.peek(length), 2, ~message="Length should update to 2")
+
+      Assert.combineResults([result1, result2, result3])
+    }),
+    Test.make("computed with structural equality for tuples", () => {
+      // Test structural equality comparison for tuple values
+      let position = Signal.make((0, 0))
+
+      // Computed with structural equality for point tuple
+      let currentPos = Computed.make(
+        () => Signal.get(position),
+        ~equals=((ax, ay), (bx, by)) => ax == bx && ay == by,
+      )
+
+      let posSum = Computed.make(() => {
+        let (x, y) = Signal.get(currentPos)
+        x + y
+      })
+
+      let result1 = Assert.equal(Signal.peek(posSum), 0, ~message="Initial sum should be 0")
+
+      // Set to structurally equal point (different reference)
+      Signal.set(position, (0, 0))
+      let result2 = Assert.equal(Signal.peek(posSum), 0, ~message="Sum should still be 0")
+
+      // Set to different point
+      Signal.set(position, (10, 20))
+      let result3 = Assert.equal(Signal.peek(posSum), 30, ~message="Sum should update to 30")
+
+      Assert.combineResults([result1, result2, result3])
+    }),
+    Test.make("chained computeds with equality short-circuit", () => {
+      let source = Signal.make(10)
+      let middleComputeCount = ref(0)
+      let finalComputeCount = ref(0)
+
+      // Middle computed: clamps value to 0-100 range
+      let clamp = (min, max, v) =>
+        if v < min {
+          min
+        } else if v > max {
+          max
+        } else {
+          v
+        }
+
+      let clamped = Computed.make(
+        () => {
+          middleComputeCount := middleComputeCount.contents + 1
+          clamp(0, 100, Signal.get(source))
+        },
+        ~equals=(a, b) => a == b,
+      )
+
+      // Final computed depends on clamped
+      let doubled = Computed.make(
+        () => {
+          finalComputeCount := finalComputeCount.contents + 1
+          Signal.get(clamped) * 2
+        },
+        ~equals=(a, b) => a == b,
+      )
+
+      let _ = Signal.peek(doubled)
+      let result1 = Assert.equal(Signal.peek(doubled), 20, ~message="Initial value should be 20")
+
+      // Change source but clamped result stays the same (still 10)
+      Signal.set(source, 10)
+      let _ = Signal.peek(doubled)
+
+      // Change source to value that clamps to same result
+      let _beforeMiddle = middleComputeCount.contents
+      let _beforeFinal = finalComputeCount.contents
+      Signal.set(source, 10) // Same value
+      let _ = Signal.peek(doubled)
+
+      let result2 = Assert.equal(
+        Signal.peek(doubled),
+        20,
+        ~message="Value should still be 20",
+      )
+
+      // Change to different clamped value
+      Signal.set(source, 50)
+      let _ = Signal.peek(doubled)
+
+      let result3 = Assert.equal(
+        Signal.peek(doubled),
+        100,
+        ~message="Value should update to 100",
+      )
+
+      Assert.combineResults([result1, result2, result3])
+    }),
   ],
 )

--- a/packages/rescript-signals/tests/EffectTests.res
+++ b/packages/rescript-signals/tests/EffectTests.res
@@ -165,6 +165,102 @@ let tests = Suite.make(
       disposer.dispose()
       result
     }),
+    Test.make("flush drains effects enqueued by running effects", () => {
+      let trigger = Signal.make(0)
+      let derived = Signal.make(0)
+      let derivedRuns = ref(0)
+
+      let derivedDisposer = Effect.runWithDisposer(() => {
+        ignore(Signal.get(derived))
+        derivedRuns := derivedRuns.contents + 1
+        None
+      })
+
+      let triggerDisposer = Effect.runWithDisposer(() => {
+        let value = Signal.get(trigger)
+        if value > 0 {
+          Signal.set(derived, value)
+        }
+        None
+      })
+
+      Signal.set(trigger, 1)
+
+      let result = Assert.equal(
+        derivedRuns.contents,
+        2,
+        ~message="Derived effect should run in same flush when enqueued by another effect",
+      )
+
+      triggerDisposer.dispose()
+      derivedDisposer.dispose()
+      result
+    }),
+    Test.make("nested effect creation preserves outer effect dependency", () => {
+      let trigger = Signal.make(0)
+      let source = Signal.make(0)
+      let outerRuns = ref(0)
+      let innerDisposer: ref<option<Effect.disposer>> = ref(None)
+
+      let outerDisposer = Effect.runWithDisposer(() => {
+        let t = Signal.get(trigger)
+        if t == 1 && innerDisposer.contents === None {
+          let created = Effect.runWithDisposer(() => {
+            ignore(Signal.get(source))
+            None
+          })
+          innerDisposer := Some(created)
+        }
+        ignore(Signal.get(source))
+        outerRuns := outerRuns.contents + 1
+        None
+      })
+
+      Signal.set(trigger, 1)
+      Signal.set(source, 1)
+
+      let result = Assert.equal(
+        outerRuns.contents,
+        3,
+        ~message="Outer effect should still rerun when source changes after nested effect creation",
+      )
+
+      switch innerDisposer.contents {
+      | Some(disposer) => disposer.dispose()
+      | None => ()
+      }
+      outerDisposer.dispose()
+      result
+    }),
+    Test.make("nested computed creation preserves outer computed dependency", () => {
+      let trigger = Signal.make(0)
+      let source = Signal.make(0)
+
+      let outerComputed = Computed.make(() => {
+        ignore(Signal.get(trigger))
+        let _nested = Computed.make(() => Signal.get(source) + 1)
+        Signal.get(source)
+      })
+
+      let outerRuns = ref(0)
+      let disposer = Effect.runWithDisposer(() => {
+        ignore(Signal.get(outerComputed))
+        outerRuns := outerRuns.contents + 1
+        None
+      })
+
+      Signal.set(trigger, 1)
+      Signal.set(source, 1)
+
+      let result = Assert.equal(
+        outerRuns.contents,
+        3,
+        ~message="Outer computed should stay subscribed to source after nested computed creation",
+      )
+
+      disposer.dispose()
+      result
+    }),
     Test.make("multiple disposals are safe", () => {
       let disposer = Effect.runWithDisposer(() => None)
       disposer.dispose()


### PR DESCRIPTION
## Summary
- Migrated scheduler internals to version-based dependency tracking with link reuse.
- Kept `lastDep` as a true tail pointer and added per-run dependency cursors for fast reuse.
- Added cursor ownership guards to avoid nested tracking edge cases.
- Unified computed recompute flow in `runComputedCycle` and removed per-run full dep clears.
- Fixed flush behavior to preserve effects queued during the same flush cycle.
- Propagate from computeds only when value actually changes.
- Defer effect propagation behind computed recompute only for computeds using custom `~equals`.
- Added a computed freshness fast path using global mutation version stamps.
- Added signal notify fast path for direct-effect-only subscriber lists.
- Replaced queue pre-scan sort checks with enqueue-time sort flags.
- Split computed construction into fast path (no `~equals`) and full path (custom `~equals`).

## API
- Public API is unchanged.
- `Computed.make` still supports optional `~equals`.

## Validation
- `npm run build && npm run test` passes for both workspaces.

## Benchmarks
- Benchmark runs and detailed numbers are tracked in PR comments.
- Includes:
  - `ReScript Signals (main)` vs `ReScript Signals (current)`
  - `ReScript Signals` vs selected top frameworks in `milomg/js-reactivity-benchmark`

## Notes
- Benchmark CI automation was extracted into a separate branch/PR (`ci-benchmark-workflows`) so it can be merged independently first.