### PR TITLE
fix: restore Signals entrypoint module

### DIFF
--- a/packages/rescript-signals/src/Signals.res
+++ b/packages/rescript-signals/src/Signals.res
@@ -1,0 +1,3 @@
+module Signal = Signal
+module Computed = Computed
+module Effect = Effect


### PR DESCRIPTION
## Summary
- Reintroduce a top-level  entry module exporting , , and .
- Fixes the npm entrypoint regression that prevents Bundlephobia from resolving .

## Verification
- npm run build
- npm run test