### PR TITLE
feat: auto-tracking for React and the @tracked annotation

### DIFF
--- a/.github/workflows/benchmark-pr-vs-frameworks.yml
+++ b/.github/workflows/benchmark-pr-vs-frameworks.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install repository dependencies
         run: npm ci
 
+      - name: Setup OCaml (for rescript-tracked-ppx)
+        run: sudo apt-get update && sudo apt-get install -y ocaml-nox
+
       - name: Build repository
         run: npm run build
 

--- a/.github/workflows/benchmark-pr-vs-main.yml
+++ b/.github/workflows/benchmark-pr-vs-main.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install repository dependencies
         run: npm ci
 
+      - name: Setup OCaml (for rescript-tracked-ppx)
+        run: sudo apt-get update && sudo apt-get install -y ocaml-nox
+
       - name: Build repository
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: 'lts/*'
 
+      - name: Setup OCaml (for rescript-tracked-ppx)
+        run: sudo apt-get update && sudo apt-get install -y ocaml-nox
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup OCaml (for rescript-tracked-ppx)
+        run: sudo apt-get update && sudo apt-get install -y ocaml-nox
+
       - name: Build
         run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,6 +6593,10 @@
       "resolved": "packages/rescript-signals-react",
       "link": true
     },
+    "node_modules/rescript-tracked-ppx": {
+      "resolved": "packages/rescript-tracked-ppx",
+      "link": true
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -8294,7 +8298,7 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "packages/rescript-signals-react": {
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@rescript/react": "^0.13.1",
@@ -8618,6 +8622,9 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "packages/rescript-tracked-ppx": {
+      "version": "0.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "private": true,
   "workspaces": ["packages/*"],
   "scripts": {
-    "build": "npm run build --workspaces",
-    "test": "npm run test --workspaces",
-    "clean": "npm run clean --workspaces",
+    "build": "npm run build --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
+    "clean": "npm run clean --workspaces --if-present",
     "release": "npm run release --workspace=packages/rescript-signals && npm run release --workspace=packages/rescript-signals-react",
     "prepare": "husky"
   },

--- a/packages/rescript-signals-react/package.json
+++ b/packages/rescript-signals-react/package.json
@@ -17,7 +17,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "rescript && node tests/SignalsReact_test.res.mjs",
+    "test": "rescript && node tests/SignalsReact_test.res.mjs && node tests/SignalsReactAuto_test.res.mjs",
     "build": "rescript",
     "clean": "rescript clean",
     "prepack": "node scripts/prepack.cjs",

--- a/packages/rescript-signals-react/package.json
+++ b/packages/rescript-signals-react/package.json
@@ -17,8 +17,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "rescript && node tests/SignalsReact_test.res.mjs && node tests/SignalsReactAuto_test.res.mjs",
-    "build": "rescript",
+    "build:ppx": "npm run build -w rescript-tracked-ppx",
+    "test": "npm run build:ppx && rescript && node tests/SignalsReact_test.res.mjs && node tests/SignalsReactAuto_test.res.mjs && node tests/TrackedPpx_test.res.mjs",
+    "build": "npm run build:ppx && rescript",
     "clean": "rescript clean",
     "prepack": "node scripts/prepack.cjs",
     "postpack": "node scripts/postpack.cjs",

--- a/packages/rescript-signals-react/rescript.json
+++ b/packages/rescript-signals-react/rescript.json
@@ -10,6 +10,7 @@
       "type": "dev"
     }
   ],
+  "ppx-flags": ["rescript-tracked-ppx/ppx"],
   "package-specs": {
     "module": "esmodule",
     "in-source": true

--- a/packages/rescript-signals-react/src/SignalsReactAuto.res
+++ b/packages/rescript-signals-react/src/SignalsReactAuto.res
@@ -1,0 +1,78 @@
+open Signals
+
+// ---------------------------------------------------------------------------
+// Automatic signal tracking for React (single-pass).
+//
+// Reading a signal inside the render thunk subscribes the component
+// automatically — no explicit per-signal hook:
+//
+//   @react.component
+//   let make = (~a, ~b) =>
+//     useTracked(() => <div> {React.int(Signal.get(a) + Signal.get(b))} </div>)
+//
+// The display render IS the tracking pass: it is bracketed by the core
+// `Tracking` scope — a notify-only observer that the scheduler notifies (but
+// never auto-retracks) when a dependency changes. React re-renders, and that
+// render re-establishes dependencies via `Tracking.track`, so the thunk runs
+// exactly once per update and conditional reads are re-discovered each time.
+//
+// Tradeoff: dependency tracking happens during render (it reconciles the
+// scope's dependency set). A render discarded by concurrent React leaves
+// dependencies reflecting the discarded pass until the committed render
+// re-tracks; `useSyncExternalStore` still guards against tearing.
+// ---------------------------------------------------------------------------
+
+type holder = {
+  mutable version: int,
+  mutable onStoreChange: unit => unit,
+}
+
+type store<'a> = {
+  holder: holder,
+  scope: Tracking.scope,
+  // Latest closure, refreshed every render so any out-of-render re-track
+  // (StrictMode repair) still reads current props/context values.
+  mutable render: unit => 'a,
+}
+
+/** Run `render` with ambient dependency tracking and subscribe the component to
+    every signal it reads. Re-renders when any tracked signal changes and
+    re-discovers dependencies each render, so conditional reads work. Single
+    pass: the thunk runs once per render. Concurrent/StrictMode safe via
+    `useSyncExternalStore`, modulo the render-phase-tracking caveat noted above. */
+let useTracked = (render: unit => 'a): 'a => {
+  let storeRef = React.useRef(None)
+  let store = switch storeRef.current {
+  | Some(s) => s
+  | None =>
+    let holder = {version: 0, onStoreChange: () => ()}
+    // Notify-only: on a tracked-dep change, bump the snapshot and poke React.
+    let scope = Tracking.makeScope(~onInvalidate=() => {
+      holder.version = holder.version + 1
+      holder.onStoreChange()
+    })
+    let s: store<'a> = {holder, scope, render}
+    storeRef.current = Some(s)
+    s
+  }
+  store.render = render
+
+  let subscribe = React.useCallback(onStoreChange => {
+    store.holder.onStoreChange = onStoreChange
+    () => store.holder.onStoreChange = () => ()
+  }, [store])
+  let getSnapshot = React.useCallback(() => store.holder.version, [store])
+  let _: int = React.useSyncExternalStore(~subscribe, ~getSnapshot)
+
+  // Lifetime: dispose on unmount. If a previous (StrictMode) cleanup disposed
+  // our dependencies, re-establish them so the committed tree stays reactive.
+  React.useEffect(() => {
+    if Tracking.isEmpty(store.scope) {
+      let _ = Tracking.track(store.scope, store.render)
+    }
+    Some(() => Tracking.dispose(store.scope))
+  }, [store])
+
+  // Single pass: this render establishes the dependency set and produces output.
+  Tracking.track(store.scope, render)
+}

--- a/packages/rescript-signals-react/src/SignalsReactAuto.res
+++ b/packages/rescript-signals-react/src/SignalsReactAuto.res
@@ -76,3 +76,29 @@ let useTracked = (render: unit => 'a): 'a => {
   // Single pass: this render establishes the dependency set and produces output.
   Tracking.track(store.scope, render)
 }
+
+// ---------------------------------------------------------------------------
+// Explicit-dependency form.
+//
+//   @react.component
+//   let make = (~a, ~b, ~c) => {
+//     useSignals([dep(a), dep(b)])       // subscribe to a and b
+//     <div> {React.string(Int.toString(Signal.get(a) + Signal.get(b)))}
+//           {React.string(c)} </div>     // read them (and plain props) freely
+//   }
+//
+// List the signal dependencies once, then read them anywhere in the body.
+// `dep` type-erases the heterogeneous signals so they fit in one array. Like a
+// React dependency array, this is explicit: a signal read but not listed will
+// not trigger a re-render. For automatic discovery, use `useTracked`.
+// ---------------------------------------------------------------------------
+
+type dep = unit => unit
+
+/** Wrap a signal as an untyped dependency for `useSignals`. */
+let dep = (signal: Signal.t<'a>): dep => () => Signal.get(signal)->ignore
+
+/** Subscribe the component to every signal in `deps` and re-render when any of
+    them changes. Reads in the body stay plain `Signal.get`. Dependencies are
+    reconciled each render, so a dynamic `deps` array is fine. */
+let useSignals = (deps: array<dep>): unit => useTracked(() => deps->Array.forEach(d => d()))

--- a/packages/rescript-signals-react/tests/SignalsReactAuto_test.res
+++ b/packages/rescript-signals-react/tests/SignalsReactAuto_test.res
@@ -1,0 +1,165 @@
+open Signals
+open Zekr
+open Types
+open ReactTestingUtils
+
+@send external querySelector: (Dom.element, string) => Dom.element = "querySelector"
+@send external click: Dom.element => unit = "click"
+
+// ---------------------------------------------------------------------------
+// Auto-tracking: Signal.get inside useTracked subscribes the component
+// ---------------------------------------------------------------------------
+
+module AutoTrackTest = {
+  module Sum = {
+    @react.component
+    let make = (~a: Signal.t<int>, ~b: Signal.t<int>, ~renderCount: ref<int>) => {
+      SignalsReactAuto.useTracked(() => {
+        renderCount := renderCount.contents + 1
+        <div> {React.string(Int.toString(Signal.get(a) + Signal.get(b)))} </div>
+      })
+    }
+  }
+
+  // Reads `other` only while `flag` is true — exercises dynamic dependencies.
+  module Conditional = {
+    @react.component
+    let make = (~flag: Signal.t<bool>, ~other: Signal.t<int>) => {
+      SignalsReactAuto.useTracked(() =>
+        <div>
+          {React.string(Signal.get(flag) ? Int.toString(Signal.get(other)) : "off")}
+        </div>
+      )
+    }
+  }
+
+  // A React prop drives one part, a signal the other — proves no stale props.
+  module PropAndSignal = {
+    @react.component
+    let make = (~label: string, ~signal: Signal.t<int>) => {
+      SignalsReactAuto.useTracked(() =>
+        <div> {React.string(`${label}:${Int.toString(Signal.get(signal))}`)} </div>
+      )
+    }
+  }
+
+  module PropParent = {
+    @react.component
+    let make = (~signal: Signal.t<int>) => {
+      let (label, setLabel) = React.useState(() => "a")
+      <div>
+        <PropAndSignal label signal />
+        <button onClick={_ => setLabel(_ => "b")}> {React.string("relabel")} </button>
+      </div>
+    }
+  }
+
+  let rendered = ref(None)
+
+  let suite = Suite.make(
+    "useTracked (auto-tracking)",
+    [
+      Test.make("subscribes to every signal read in the thunk", () => {
+        let a = Signal.make(3)
+        let b = Signal.make(4)
+        let rc = ref(0)
+        let r = renderComponent(<Sum a b renderCount=rc />)
+        rendered := Some(r)
+        Assert.combineResults([
+          Assert.equal(r.container->textContent, "7"),
+          {
+            act(() => Signal.set(a, 10))
+            Assert.equal(r.container->textContent, "14")
+          },
+          {
+            act(() => Signal.set(b, 100))
+            Assert.equal(r.container->textContent, "110")
+          },
+        ])
+      }),
+      Test.make("re-discovers dependencies (conditional reads)", () => {
+        let flag = Signal.make(false)
+        let other = Signal.make(1)
+        let r = renderComponent(<Conditional flag other />)
+        rendered := Some(r)
+        Assert.combineResults([
+          // flag=false: `other` is not read, so changing it must NOT re-render
+          Assert.equal(r.container->textContent, "off"),
+          {
+            act(() => Signal.set(other, 42))
+            Assert.equal(r.container->textContent, "off")
+          },
+          // flip flag on -> now `other` is tracked
+          {
+            act(() => Signal.set(flag, true))
+            Assert.equal(r.container->textContent, "42")
+          },
+          {
+            act(() => Signal.set(other, 99))
+            Assert.equal(r.container->textContent, "99")
+          },
+        ])
+      }),
+      Test.make("no stale props: prop change re-renders with fresh value", () => {
+        let signal = Signal.make(5)
+        let r = renderComponent(<PropParent signal />)
+        rendered := Some(r)
+        let btn = r.container->querySelector("button")
+        Assert.combineResults([
+          Assert.contains(r.container->textContent, "a:5"),
+          // change the signal -> tracked
+          {
+            act(() => Signal.set(signal, 6))
+            Assert.contains(r.container->textContent, "a:6")
+          },
+          // change the React prop -> fresh label, signal value preserved
+          {
+            act(() => btn->click)
+            Assert.contains(r.container->textContent, "b:6")
+          },
+          // still reactive after the prop-driven render
+          {
+            act(() => Signal.set(signal, 7))
+            Assert.contains(r.container->textContent, "b:7")
+          },
+        ])
+      }),
+      Test.make("cost: single pass — thunk runs once per update", () => {
+        let a = Signal.make(0)
+        let b = Signal.make(0)
+        let rc = ref(0)
+        let r = renderComponent(<Sum a b renderCount=rc />)
+        rendered := Some(r)
+        // Mount: the display render is the tracking pass = 1
+        let afterMount = rc.contents
+        act(() => Signal.set(a, 1))
+        // Each update: one React render, which re-establishes deps = 1
+        let afterOneUpdate = rc.contents
+        Assert.combineResults([
+          Assert.equal(afterMount, 1),
+          Assert.equal(afterOneUpdate - afterMount, 1),
+        ])
+      }),
+      Test.make("stops notifying after unmount", () => {
+        let a = Signal.make(0)
+        let b = Signal.make(0)
+        let rc = ref(0)
+        let r = renderComponent(<Sum a b renderCount=rc />)
+        cleanup(r)
+        // Should not throw and should not re-render a disposed tree.
+        Signal.set(a, 999)
+        Pass
+      }),
+    ],
+    ~afterEach=() => {
+      switch rendered.contents {
+      | Some(r) =>
+        cleanup(r)
+        rendered := None
+      | None => ()
+      }
+    },
+  )
+}
+
+Runner.runSuites([AutoTrackTest.suite])

--- a/packages/rescript-signals-react/tests/SignalsReactAuto_test.res
+++ b/packages/rescript-signals-react/tests/SignalsReactAuto_test.res
@@ -162,4 +162,97 @@ module AutoTrackTest = {
   )
 }
 
-Runner.runSuites([AutoTrackTest.suite])
+// ---------------------------------------------------------------------------
+// Explicit-dependency form: useSignals([dep(a), dep(b)])
+// ---------------------------------------------------------------------------
+
+module ExplicitDepsTest = {
+  // Lists a and b, reads a, b, and a plain string prop c.
+  module Listed = {
+    @react.component
+    let make = (~a: Signal.t<int>, ~b: Signal.t<int>, ~c: string) => {
+      SignalsReactAuto.useSignals([SignalsReactAuto.dep(a), SignalsReactAuto.dep(b)])
+      <div> {React.string(`${Int.toString(Signal.get(a) + Signal.get(b))}-${c}`)} </div>
+    }
+  }
+
+  module Parent = {
+    @react.component
+    let make = (~a: Signal.t<int>, ~b: Signal.t<int>) => {
+      let (c, setC) = React.useState(() => "x")
+      <div>
+        <Listed a b c />
+        <button onClick={_ => setC(_ => "y")}> {React.string("setc")} </button>
+      </div>
+    }
+  }
+
+  // Reads `unlisted` but only lists `listed` — demonstrates the dep-array
+  // footgun: the unlisted read does not cause a re-render.
+  module ForgotToList = {
+    @react.component
+    let make = (~listed: Signal.t<int>, ~unlisted: Signal.t<int>) => {
+      SignalsReactAuto.useSignals([SignalsReactAuto.dep(listed)])
+      <div> {React.string(`${Int.toString(Signal.get(listed))}/${Int.toString(Signal.get(unlisted))}`)} </div>
+    }
+  }
+
+  let rendered = ref(None)
+
+  let suite = Suite.make(
+    "useSignals (explicit deps)",
+    [
+      Test.make("re-renders when any listed signal changes", () => {
+        let a = Signal.make(1)
+        let b = Signal.make(2)
+        let r = renderComponent(<Parent a b />)
+        rendered := Some(r)
+        Assert.combineResults([
+          Assert.contains(r.container->textContent, "3-x"),
+          {
+            act(() => Signal.set(a, 10))
+            Assert.contains(r.container->textContent, "12-x")
+          },
+          {
+            act(() => Signal.set(b, 20))
+            Assert.contains(r.container->textContent, "30-x")
+          },
+          // plain prop still flows through
+          {
+            act(() => r.container->querySelector("button")->click)
+            Assert.contains(r.container->textContent, "30-y")
+          },
+        ])
+      }),
+      Test.make("does NOT re-render for a read-but-unlisted signal", () => {
+        let listed = Signal.make(1)
+        let unlisted = Signal.make(1)
+        let r = renderComponent(<ForgotToList listed unlisted />)
+        rendered := Some(r)
+        Assert.combineResults([
+          Assert.contains(r.container->textContent, "1/1"),
+          // unlisted change: read value is stale until a listed change re-renders
+          {
+            act(() => Signal.set(unlisted, 99))
+            Assert.contains(r.container->textContent, "1/1")
+          },
+          // listed change re-renders and picks up the latest unlisted value too
+          {
+            act(() => Signal.set(listed, 2))
+            Assert.contains(r.container->textContent, "2/99")
+          },
+        ])
+      }),
+    ],
+    ~afterEach=() => {
+      switch rendered.contents {
+      | Some(r) =>
+        cleanup(r)
+        rendered := None
+      | None => ()
+      }
+    },
+  )
+}
+
+Runner.runSuites([AutoTrackTest.suite, ExplicitDepsTest.suite])

--- a/packages/rescript-signals-react/tests/TrackedPpx_test.res
+++ b/packages/rescript-signals-react/tests/TrackedPpx_test.res
@@ -1,0 +1,89 @@
+open Signals
+open Zekr
+open ReactTestingUtils
+
+// Compiled directly through rescript-tracked-ppx: the @tracked([...]) attribute
+// is expanded to SignalsReactAuto.useSignals([dep(...), ...]) at compile time.
+
+@send external querySelector: (Dom.element, string) => Dom.element = "querySelector"
+@send external click: Dom.element => unit = "click"
+
+module Counter = {
+  @react.component
+  let make = (~a: Signal.t<int>, ~b: Signal.t<int>, ~c: string) => {
+    @tracked([a, b])
+    <div> {React.string(`${Int.toString(Signal.get(a) + Signal.get(b))}-${c}`)} </div>
+  }
+}
+
+module Parent = {
+  @react.component
+  let make = (~a: Signal.t<int>, ~b: Signal.t<int>) => {
+    let (c, setC) = React.useState(() => "x")
+    <div>
+      <Counter a b c />
+      <button onClick={_ => setC(_ => "y")}> {React.string("setc")} </button>
+    </div>
+  }
+}
+
+// Bare @tracked() — automatic discovery, no dependency list.
+module Auto = {
+  @react.component
+  let make = (~x: Signal.t<int>) => {
+    @tracked()
+    <div> {React.string(Int.toString(Signal.get(x) * 2))} </div>
+  }
+}
+
+let rendered = ref(None)
+
+let suite = Suite.make(
+  "tracked annotation (ppx)",
+  [
+    Test.make("@tracked([a, b]) subscribes to listed signals", () => {
+      let a = Signal.make(1)
+      let b = Signal.make(2)
+      let r = renderComponent(<Parent a b />)
+      rendered := Some(r)
+      Assert.combineResults([
+        Assert.contains(r.container->textContent, "3-x"),
+        {
+          act(() => Signal.set(a, 10))
+          Assert.contains(r.container->textContent, "12-x")
+        },
+        {
+          act(() => Signal.set(b, 20))
+          Assert.contains(r.container->textContent, "30-x")
+        },
+        // plain prop still flows through
+        {
+          act(() => r.container->querySelector("button")->click)
+          Assert.contains(r.container->textContent, "30-y")
+        },
+      ])
+    }),
+    Test.make("@tracked() auto-discovers dependencies", () => {
+      let x = Signal.make(5)
+      let r = renderComponent(<Auto x />)
+      rendered := Some(r)
+      Assert.combineResults([
+        Assert.equal(r.container->textContent, "10"),
+        {
+          act(() => Signal.set(x, 7))
+          Assert.equal(r.container->textContent, "14")
+        },
+      ])
+    }),
+  ],
+  ~afterEach=() => {
+    switch rendered.contents {
+    | Some(r) =>
+      cleanup(r)
+      rendered := None
+    | None => ()
+    }
+  },
+)
+
+Runner.runSuites([suite])

--- a/packages/rescript-signals/src/Signals.res
+++ b/packages/rescript-signals/src/Signals.res
@@ -1,3 +1,4 @@
 module Signal = Signal
 module Computed = Computed
 module Effect = Effect
+module Tracking = Tracking

--- a/packages/rescript-signals/src/signals/Core.res
+++ b/packages/rescript-signals/src/signals/Core.res
@@ -5,6 +5,10 @@
 let flag_dirty = 1
 let flag_pending = 2
 let flag_running = 4
+// Manual observers are driven externally (e.g. by a React render). When a
+// dependency changes they are notified via `run` but NOT auto-retracked by the
+// scheduler; the external driver re-establishes deps by calling Scheduler.track.
+let flag_manual = 8
 
 // Global tracking version
 let trackingVersion: ref<int> = ref(0)
@@ -125,6 +129,8 @@ let isDirty = (o: observer): bool => Int.bitwiseAnd(o.flags, flag_dirty) !== 0
 let setDirty = (o: observer): unit => o.flags = Int.bitwiseOr(o.flags, flag_dirty)
 let clearDirty = (o: observer): unit =>
   o.flags = Int.bitwiseAnd(o.flags, Int.bitwiseNot(flag_dirty))
+let isManualObs = (o: observer): bool => Int.bitwiseAnd(o.flags, flag_manual) !== 0
+let setManualObs = (o: observer): unit => o.flags = Int.bitwiseOr(o.flags, flag_manual)
 let isPending = (o: observer): bool => Int.bitwiseAnd(o.flags, flag_pending) !== 0
 let setPending = (o: observer): unit => o.flags = Int.bitwiseOr(o.flags, flag_pending)
 let clearPending = (o: observer): unit =>

--- a/packages/rescript-signals/src/signals/Scheduler.res
+++ b/packages/rescript-signals/src/signals/Scheduler.res
@@ -427,6 +427,63 @@ let retrackEffect = (observer: Core.observer): unit => {
   }
 }
 
+// Run `body` as the current observer, reconciling this observer's dependency
+// set to exactly the signals read during `body`. Mirrors retrackEffect, but the
+// body is supplied externally (e.g. a React render) and its result is returned.
+// Used by manual observers to establish deps during the render that displays
+// them — a single tracking pass rather than a separate recompute.
+let track = (observer: Core.observer, body: unit => 'a): 'a => {
+  let oldLevel = observer.level
+  let previousTrackingVersion = currentTrackingVersion.contents
+
+  Core.trackingVersion := Core.trackingVersion.contents + 1
+  currentTrackingVersion.contents = Core.trackingVersion.contents
+
+  Core.clearPending(observer)
+
+  let prev = currentObserver.contents
+  let prevCursor = currentObserverDepCursor.contents
+  currentObserver := Some(observer)
+  currentObserverDepCursor := observer.firstDep
+
+  let result = try {
+    let r = body()
+
+    // After the body: unlink stale deps (version != current)
+    let link = ref(observer.firstDep)
+    while link.contents !== None {
+      switch link.contents {
+      | Some(l) =>
+        let next = l.nextDep
+        if l.lastTrackedVersion !== currentTrackingVersion.contents {
+          Core.unlinkFromSubs(l)
+          Core.unlinkFromDeps(observer, l)
+        }
+        link := next
+      | None => ()
+      }
+    }
+
+    Core.clearDirty(observer)
+    currentObserver := prev
+    currentObserverDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
+    r
+  } catch {
+  | exn =>
+    currentObserver := prev
+    currentObserverDepCursor := prevCursor
+    currentTrackingVersion.contents = previousTrackingVersion
+    throw(exn)
+  }
+
+  if oldLevel == 0 {
+    observer.level = computeLevel(observer)
+  }
+
+  result
+}
+
 // Flush pending observers
 let flush = (): unit => {
   flushing := true
@@ -465,7 +522,15 @@ let flush = (): unit => {
         let i = ref(0)
         while i.contents < effectsLength {
           switch pendingEffects->Array.get(i.contents) {
-          | Some(effect) => retrackEffect(effect)
+          | Some(effect) =>
+            if Core.isManualObs(effect) {
+              // Notify-only: the external driver (e.g. React) re-establishes
+              // deps via `track` on its next render. Do not retrack here.
+              Core.clearPending(effect)
+              effect.run()
+            } else {
+              retrackEffect(effect)
+            }
           | None => ()
           }
           i := i.contents + 1

--- a/packages/rescript-signals/src/signals/Tracking.res
+++ b/packages/rescript-signals/src/signals/Tracking.res
@@ -1,0 +1,20 @@
+// Framework-agnostic reactive scope for externally-driven consumers (e.g. a
+// React render). Unlike an Effect, a scope is NOT recomputed by the scheduler
+// when a dependency changes — it is only notified. The driver then re-runs its
+// own body through `track`, which reconciles the scope's dependency set. This
+// lets a UI framework establish dependencies during the very render that
+// displays them (a single tracking pass).
+
+type scope = {observer: Core.observer}
+
+let makeScope = (~onInvalidate: unit => unit): scope => {
+  let observer = Core.makeObserver(Id.make(), #Effect, onInvalidate)
+  Core.setManualObs(observer)
+  {observer: observer}
+}
+
+let track = (scope: scope, body: unit => 'a): 'a => Scheduler.track(scope.observer, body)
+
+let dispose = (scope: scope): unit => Core.clearDeps(scope.observer)
+
+let isEmpty = (scope: scope): bool => scope.observer.firstDep === None

--- a/packages/rescript-signals/src/signals/Tracking.resi
+++ b/packages/rescript-signals/src/signals/Tracking.resi
@@ -1,0 +1,21 @@
+/** A reactive scope driven externally (e.g. by a React render) rather than by
+    the scheduler. When a tracked dependency changes the scope is *notified*,
+    not recomputed — the driver re-establishes dependencies by calling `track`
+    again. This enables single-pass dependency tracking during the render that
+    displays the values. */
+type scope
+
+/** Create a scope. `onInvalidate` fires (synchronously, during the scheduler
+    flush) whenever any signal read during the most recent `track` changes. */
+let makeScope: (~onInvalidate: unit => unit) => scope
+
+/** Run `body` as the current observer, reconciling this scope's dependency set
+    to exactly the signals read during `body`, and return `body`'s result.
+    Dependencies are re-discovered on every call, so conditional reads work. */
+let track: (scope, unit => 'a) => 'a
+
+/** Unsubscribe the scope from all tracked signals. */
+let dispose: scope => unit
+
+/** Whether the scope currently tracks no dependencies. */
+let isEmpty: scope => bool

--- a/packages/rescript-tracked-ppx/.gitignore
+++ b/packages/rescript-tracked-ppx/.gitignore
@@ -1,0 +1,4 @@
+ppx
+*.cmi
+*.cmx
+*.o

--- a/packages/rescript-tracked-ppx/README.md
+++ b/packages/rescript-tracked-ppx/README.md
@@ -1,0 +1,55 @@
+# rescript-tracked-ppx
+
+A native ReScript PPX that expands the `@tracked` annotation into the
+`rescript-signals-react` auto-tracking hooks at compile time.
+
+```rescript
+@react.component
+let make = (~a, ~b, ~c) => {
+  @tracked([a, b])
+  <div> {React.string(Int.toString(Signal.get(a) + Signal.get(b)))} {React.string(c)} </div>
+}
+```
+
+expands to:
+
+```rescript
+@react.component
+let make = (~a, ~b, ~c) => {
+  SignalsReactAuto.useSignals([SignalsReactAuto.dep(a), SignalsReactAuto.dep(b)])
+  <div> {React.string(Int.toString(Signal.get(a) + Signal.get(b)))} {React.string(c)} </div>
+}
+```
+
+## Supported syntax
+
+- `@tracked([a, b, ...])` — explicit dependency list. Expands to
+  `SignalsReactAuto.useSignals([dep(a), dep(b)])`.
+- `@tracked()` (or bare `@tracked`) — automatic discovery. Expands to
+  `SignalsReactAuto.useTracked(() => <body>)`; any `Signal.get` read inside the
+  body subscribes the component automatically.
+
+The generated thunk is emitted as `Function$(fun () => ...)` with a `res.arity`
+attribute, the encoding ReScript uses for uncurried functions in the ppx AST
+(see `ast_mapper_from0.ml`); a bare `Pexp_fun` would be imported as curried and
+rejected by uncurried-by-default mode.
+
+## How it works
+
+ReScript 12 hands an external ppx an OCaml **4.06** parsetree (marshal magic
+`Caml1999M022`). `ppx.ml` vendors those exact 4.06 AST types (copied from
+`ocaml/ocaml@4.06`) so `Marshal` round-trips faithfully, implements the
+`ppx <infile> <outfile>` protocol, and rewrites expressions carrying the
+`tracked` attribute. The only build dependency is `ocamlopt` — no opam/dune.
+
+## Build
+
+```bash
+sh build.sh   # produces ./ppx
+```
+
+Wire it into a project's `rescript.json`:
+
+```json
+{ "ppx-flags": ["rescript-tracked-ppx/ppx"] }
+```

--- a/packages/rescript-tracked-ppx/build.sh
+++ b/packages/rescript-tracked-ppx/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Compiles the @tracked ppx to a native binary using the system OCaml compiler.
+# ReScript 12 hands ppx an OCaml 4.06 parsetree; ppx.ml vendors those exact
+# types, so the only build dependency is ocamlopt (any recent OCaml works).
+set -e
+cd "$(dirname "$0")"
+ocamlopt -w -a-31 ppx.ml -o ppx
+rm -f ppx.cmi ppx.cmx ppx.o
+echo "built $(pwd)/ppx"

--- a/packages/rescript-tracked-ppx/package.json
+++ b/packages/rescript-tracked-ppx/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rescript-tracked-ppx",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Native ReScript PPX expanding the @tracked annotation.",
+  "scripts": {
+    "build": "sh build.sh"
+  }
+}

--- a/packages/rescript-tracked-ppx/ppx.ml
+++ b/packages/rescript-tracked-ppx/ppx.ml
@@ -1,0 +1,1060 @@
+(* Vendored OCaml 4.06 AST (ReScript 12's ppx parsetree is Caml1999M022 = 4.06).
+   Types are copied verbatim from ocaml/ocaml@4.06 so Marshal round-trips exactly. *)
+module Location = struct
+  type t = { loc_start : Lexing.position; loc_end : Lexing.position; loc_ghost : bool }
+  type 'a loc = { txt : 'a; loc : t }
+end
+module Longident = struct
+  type t = Lident of string | Ldot of t * string | Lapply of t * t
+end
+module Asttypes = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Auxiliary AST types used by parsetree and typedtree. *)
+
+type constant =
+    Const_int of int
+  | Const_char of char
+  | Const_string of string * string option
+  | Const_float of string
+  | Const_int32 of int32
+  | Const_int64 of int64
+  | Const_nativeint of nativeint
+
+type rec_flag = Nonrecursive | Recursive
+
+type direction_flag = Upto | Downto
+
+(* Order matters, used in polymorphic comparison *)
+type private_flag = Private | Public
+
+type mutable_flag = Immutable | Mutable
+
+type virtual_flag = Virtual | Concrete
+
+type override_flag = Override | Fresh
+
+type closed_flag = Closed | Open
+
+type label = string
+
+type arg_label =
+    Nolabel
+  | Labelled of string (*  label:T -> ... *)
+  | Optional of string (* ?label:T -> ... *)
+
+type 'a loc = 'a Location.loc = {
+  txt : 'a;
+  loc : Location.t;
+}
+
+
+type variance =
+  | Covariant
+  | Contravariant
+  | Invariant
+end
+module Parsetree = struct
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Abstract syntax tree produced by parsing *)
+
+open Asttypes
+
+type constant =
+    Pconst_integer of string * char option
+  (* 3 3l 3L 3n
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+  *)
+  | Pconst_char of char
+  (* 'c' *)
+  | Pconst_string of string * string option
+  (* "constant"
+     {delim|other constant|delim}
+  *)
+  | Pconst_float of string * char option
+  (* 3.4 2e5 1.4e-4
+
+     Suffixes [g-z][G-Z] are accepted by the parser.
+     Suffixes are rejected by the typechecker.
+  *)
+
+(** {1 Extension points} *)
+
+type attribute = string loc * payload
+       (* [@id ARG]
+          [@@id ARG]
+
+          Metadata containers passed around within the AST.
+          The compiler ignores unknown attributes.
+       *)
+
+and extension = string loc * payload
+      (* [%id ARG]
+         [%%id ARG]
+
+         Sub-language placeholder -- rejected by the typechecker.
+      *)
+
+and attributes = attribute list
+
+and payload =
+  | PStr of structure
+  | PSig of signature (* : SIG *)
+  | PTyp of core_type  (* : T *)
+  | PPat of pattern * expression option  (* ? P  or  ? P when E *)
+
+(** {1 Core language} *)
+
+(* Type expressions *)
+
+and core_type =
+    {
+     ptyp_desc: core_type_desc;
+     ptyp_loc: Location.t;
+     ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and core_type_desc =
+  | Ptyp_any
+        (*  _ *)
+  | Ptyp_var of string
+        (* 'a *)
+  | Ptyp_arrow of arg_label * core_type * core_type
+        (* T1 -> T2       Simple
+           ~l:T1 -> T2    Labelled
+           ?l:T1 -> T2    Optional
+         *)
+  | Ptyp_tuple of core_type list
+        (* T1 * ... * Tn
+
+           Invariant: n >= 2
+        *)
+  | Ptyp_constr of Longident.t loc * core_type list
+        (* tconstr
+           T tconstr
+           (T1, ..., Tn) tconstr
+         *)
+  | Ptyp_object of object_field list * closed_flag
+        (* < l1:T1; ...; ln:Tn >     (flag = Closed)
+           < l1:T1; ...; ln:Tn; .. > (flag = Open)
+         *)
+  | Ptyp_class of Longident.t loc * core_type list
+        (* #tconstr
+           T #tconstr
+           (T1, ..., Tn) #tconstr
+         *)
+  | Ptyp_alias of core_type * string
+        (* T as 'a *)
+  | Ptyp_variant of row_field list * closed_flag * label list option
+        (* [ `A|`B ]         (flag = Closed; labels = None)
+           [> `A|`B ]        (flag = Open;   labels = None)
+           [< `A|`B ]        (flag = Closed; labels = Some [])
+           [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
+         *)
+  | Ptyp_poly of string loc list * core_type
+        (* 'a1 ... 'an. T
+
+           Can only appear in the following context:
+
+           - As the core_type of a Ppat_constraint node corresponding
+             to a constraint on a let-binding: let x : 'a1 ... 'an. T
+             = e ...
+
+           - Under Cfk_virtual for methods (not values).
+
+           - As the core_type of a Pctf_method node.
+
+           - As the core_type of a Pexp_poly node.
+
+           - As the pld_type field of a label_declaration.
+
+           - As a core_type of a Ptyp_object node.
+         *)
+
+  | Ptyp_package of package_type
+        (* (module S) *)
+  | Ptyp_extension of extension
+        (* [%id] *)
+
+and package_type = Longident.t loc * (Longident.t loc * core_type) list
+      (*
+        (module S)
+        (module S with type t1 = T1 and ... and tn = Tn)
+       *)
+
+and row_field =
+  | Rtag of label loc * attributes * bool * core_type list
+        (* [`A]                   ( true,  [] )
+           [`A of T]              ( false, [T] )
+           [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
+           [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+
+          - The 2nd field is true if the tag contains a
+            constant (empty) constructor.
+          - '&' occurs when several types are used for the same constructor
+            (see 4.2 in the manual)
+
+          - TODO: switch to a record representation, and keep location
+        *)
+  | Rinherit of core_type
+        (* [ T ] *)
+
+and object_field =
+  | Otag of label loc * attributes * core_type
+  | Oinherit of core_type
+
+(* Patterns *)
+
+and pattern =
+    {
+     ppat_desc: pattern_desc;
+     ppat_loc: Location.t;
+     ppat_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and pattern_desc =
+  | Ppat_any
+        (* _ *)
+  | Ppat_var of string loc
+        (* x *)
+  | Ppat_alias of pattern * string loc
+        (* P as 'a *)
+  | Ppat_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Ppat_interval of constant * constant
+        (* 'a'..'z'
+
+           Other forms of interval are recognized by the parser
+           but rejected by the type-checker. *)
+  | Ppat_tuple of pattern list
+        (* (P1, ..., Pn)
+
+           Invariant: n >= 2
+        *)
+  | Ppat_construct of Longident.t loc * pattern option
+        (* C                None
+           C P              Some P
+           C (P1, ..., Pn)  Some (Ppat_tuple [P1; ...; Pn])
+         *)
+  | Ppat_variant of label * pattern option
+        (* `A             (None)
+           `A P           (Some P)
+         *)
+  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+        (* { l1=P1; ...; ln=Pn }     (flag = Closed)
+           { l1=P1; ...; ln=Pn; _}   (flag = Open)
+
+           Invariant: n > 0
+         *)
+  | Ppat_array of pattern list
+        (* [| P1; ...; Pn |] *)
+  | Ppat_or of pattern * pattern
+        (* P1 | P2 *)
+  | Ppat_constraint of pattern * core_type
+        (* (P : T) *)
+  | Ppat_type of Longident.t loc
+        (* #tconst *)
+  | Ppat_lazy of pattern
+        (* lazy P *)
+  | Ppat_unpack of string loc
+        (* (module P)
+           Note: (module P : S) is represented as
+           Ppat_constraint(Ppat_unpack, Ptyp_package)
+         *)
+  | Ppat_exception of pattern
+        (* exception P *)
+  | Ppat_extension of extension
+        (* [%id] *)
+  | Ppat_open of Longident.t loc * pattern
+        (* M.(P) *)
+
+(* Value expressions *)
+
+and expression =
+    {
+     pexp_desc: expression_desc;
+     pexp_loc: Location.t;
+     pexp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and expression_desc =
+  | Pexp_ident of Longident.t loc
+        (* x
+           M.x
+         *)
+  | Pexp_constant of constant
+        (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+  | Pexp_let of rec_flag * value_binding list * expression
+        (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+         *)
+  | Pexp_function of case list
+        (* function P1 -> E1 | ... | Pn -> En *)
+  | Pexp_fun of arg_label * expression option * pattern * expression
+        (* fun P -> E1                          (Simple, None)
+           fun ~l:P -> E1                       (Labelled l, None)
+           fun ?l:P -> E1                       (Optional l, None)
+           fun ?l:(P = E0) -> E1                (Optional l, Some E0)
+
+           Notes:
+           - If E0 is provided, only Optional is allowed.
+           - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
+           - "let f P = E" is represented using Pexp_fun.
+         *)
+  | Pexp_apply of expression * (arg_label * expression) list
+        (* E0 ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pexp_match of expression * case list
+        (* match E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_try of expression * case list
+        (* try E0 with P1 -> E1 | ... | Pn -> En *)
+  | Pexp_tuple of expression list
+        (* (E1, ..., En)
+
+           Invariant: n >= 2
+        *)
+  | Pexp_construct of Longident.t loc * expression option
+        (* C                None
+           C E              Some E
+           C (E1, ..., En)  Some (Pexp_tuple[E1;...;En])
+        *)
+  | Pexp_variant of label * expression option
+        (* `A             (None)
+           `A E           (Some E)
+         *)
+  | Pexp_record of (Longident.t loc * expression) list * expression option
+        (* { l1=P1; ...; ln=Pn }     (None)
+           { E0 with l1=P1; ...; ln=Pn }   (Some E0)
+
+           Invariant: n > 0
+         *)
+  | Pexp_field of expression * Longident.t loc
+        (* E.l *)
+  | Pexp_setfield of expression * Longident.t loc * expression
+        (* E1.l <- E2 *)
+  | Pexp_array of expression list
+        (* [| E1; ...; En |] *)
+  | Pexp_ifthenelse of expression * expression * expression option
+        (* if E1 then E2 else E3 *)
+  | Pexp_sequence of expression * expression
+        (* E1; E2 *)
+  | Pexp_while of expression * expression
+        (* while E1 do E2 done *)
+  | Pexp_for of
+      pattern *  expression * expression * direction_flag * expression
+        (* for i = E1 to E2 do E3 done      (flag = Upto)
+           for i = E1 downto E2 do E3 done  (flag = Downto)
+         *)
+  | Pexp_constraint of expression * core_type
+        (* (E : T) *)
+  | Pexp_coerce of expression * core_type option * core_type
+        (* (E :> T)        (None, T)
+           (E : T0 :> T)   (Some T0, T)
+         *)
+  | Pexp_send of expression * label loc
+        (*  E # m *)
+  | Pexp_new of Longident.t loc
+        (* new M.c *)
+  | Pexp_setinstvar of label loc * expression
+        (* x <- 2 *)
+  | Pexp_override of (label loc * expression) list
+        (* {< x1 = E1; ...; Xn = En >} *)
+  | Pexp_letmodule of string loc * module_expr * expression
+        (* let module M = ME in E *)
+  | Pexp_letexception of extension_constructor * expression
+        (* let exception C in E *)
+  | Pexp_assert of expression
+        (* assert E
+           Note: "assert false" is treated in a special way by the
+           type-checker. *)
+  | Pexp_lazy of expression
+        (* lazy E *)
+  | Pexp_poly of expression * core_type option
+        (* Used for method bodies.
+
+           Can only be used as the expression under Cfk_concrete
+           for methods (not values). *)
+  | Pexp_object of class_structure
+        (* object ... end *)
+  | Pexp_newtype of string loc * expression
+        (* fun (type t) -> E *)
+  | Pexp_pack of module_expr
+        (* (module ME)
+
+           (module ME : S) is represented as
+           Pexp_constraint(Pexp_pack, Ptyp_package S) *)
+  | Pexp_open of override_flag * Longident.t loc * expression
+        (* M.(E)
+           let open M in E
+           let! open M in E *)
+  | Pexp_extension of extension
+        (* [%id] *)
+  | Pexp_unreachable
+        (* . *)
+
+and case =   (* (P -> E) or (P when E0 -> E) *)
+    {
+     pc_lhs: pattern;
+     pc_guard: expression option;
+     pc_rhs: expression;
+    }
+
+(* Value descriptions *)
+
+and value_description =
+    {
+     pval_name: string loc;
+     pval_type: core_type;
+     pval_prim: string list;
+     pval_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+     pval_loc: Location.t;
+    }
+
+(*
+  val x: T                            (prim = [])
+  external x: T = "s1" ... "sn"       (prim = ["s1";..."sn"])
+*)
+
+(* Type declarations *)
+
+and type_declaration =
+    {
+     ptype_name: string loc;
+     ptype_params: (core_type * variance) list;
+           (* ('a1,...'an) t; None represents  _*)
+     ptype_cstrs: (core_type * core_type * Location.t) list;
+           (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
+     ptype_kind: type_kind;
+     ptype_private: private_flag;   (* = private ... *)
+     ptype_manifest: core_type option;  (* = T *)
+     ptype_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+     ptype_loc: Location.t;
+    }
+
+(*
+  type t                     (abstract, no manifest)
+  type t = T0                (abstract, manifest=T0)
+  type t = C of T | ...      (variant,  no manifest)
+  type t = T0 = C of T | ... (variant,  manifest=T0)
+  type t = {l: T; ...}       (record,   no manifest)
+  type t = T0 = {l : T; ...} (record,   manifest=T0)
+  type t = ..                (open,     no manifest)
+*)
+
+and type_kind =
+  | Ptype_abstract
+  | Ptype_variant of constructor_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_record of label_declaration list
+        (* Invariant: non-empty list *)
+  | Ptype_open
+
+and label_declaration =
+    {
+     pld_name: string loc;
+     pld_mutable: mutable_flag;
+     pld_type: core_type;
+     pld_loc: Location.t;
+     pld_attributes: attributes; (* l : T [@id1] [@id2] *)
+    }
+
+(*  { ...; l: T; ... }            (mutable=Immutable)
+    { ...; mutable l: T; ... }    (mutable=Mutable)
+
+    Note: T can be a Ptyp_poly.
+*)
+
+and constructor_declaration =
+    {
+     pcd_name: string loc;
+     pcd_args: constructor_arguments;
+     pcd_res: core_type option;
+     pcd_loc: Location.t;
+     pcd_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and constructor_arguments =
+  | Pcstr_tuple of core_type list
+  | Pcstr_record of label_declaration list
+
+(*
+  | C of T1 * ... * Tn     (res = None,    args = Pcstr_tuple [])
+  | C: T0                  (res = Some T0, args = [])
+  | C: T1 * ... * Tn -> T0 (res = Some T0, args = Pcstr_tuple)
+  | C of {...}             (res = None,    args = Pcstr_record)
+  | C: {...} -> T0         (res = Some T0, args = Pcstr_record)
+  | C of {...} as t        (res = None,    args = Pcstr_record)
+*)
+
+and type_extension =
+    {
+     ptyext_path: Longident.t loc;
+     ptyext_params: (core_type * variance) list;
+     ptyext_constructors: extension_constructor list;
+     ptyext_private: private_flag;
+     ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+    }
+(*
+  type t += ...
+*)
+
+and extension_constructor =
+    {
+     pext_name: string loc;
+     pext_kind : extension_constructor_kind;
+     pext_loc : Location.t;
+     pext_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+and extension_constructor_kind =
+    Pext_decl of constructor_arguments * core_type option
+      (*
+         | C of T1 * ... * Tn     ([T1; ...; Tn], None)
+         | C: T0                  ([], Some T0)
+         | C: T1 * ... * Tn -> T0 ([T1; ...; Tn], Some T0)
+       *)
+  | Pext_rebind of Longident.t loc
+      (*
+         | C = D
+       *)
+
+(** {1 Class language} *)
+
+(* Type expressions for the class language *)
+
+and class_type =
+    {
+     pcty_desc: class_type_desc;
+     pcty_loc: Location.t;
+     pcty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_type_desc =
+  | Pcty_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcty_signature of class_signature
+        (* object ... end *)
+  | Pcty_arrow of arg_label * core_type * class_type
+        (* T -> CT       Simple
+           ~l:T -> CT    Labelled l
+           ?l:T -> CT    Optional l
+         *)
+  | Pcty_extension of extension
+        (* [%id] *)
+  | Pcty_open of override_flag * Longident.t loc * class_type
+        (* let open M in CT *)
+
+and class_signature =
+    {
+     pcsig_self: core_type;
+     pcsig_fields: class_type_field list;
+    }
+(* object('selfpat) ... end
+   object ... end             (self = Ptyp_any)
+ *)
+
+and class_type_field =
+    {
+     pctf_desc: class_type_field_desc;
+     pctf_loc: Location.t;
+     pctf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_type_field_desc =
+  | Pctf_inherit of class_type
+        (* inherit CT *)
+  | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
+        (* val x: T *)
+  | Pctf_method  of (label loc * private_flag * virtual_flag * core_type)
+        (* method x: T
+
+           Note: T can be a Ptyp_poly.
+         *)
+  | Pctf_constraint  of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pctf_attribute of attribute
+        (* [@@@id] *)
+  | Pctf_extension of extension
+        (* [%%id] *)
+
+and 'a class_infos =
+    {
+     pci_virt: virtual_flag;
+     pci_params: (core_type * variance) list;
+     pci_name: string loc;
+     pci_expr: 'a;
+     pci_loc: Location.t;
+     pci_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+    }
+(* class c = ...
+   class ['a1,...,'an] c = ...
+   class virtual c = ...
+
+   Also used for "class type" declaration.
+*)
+
+and class_description = class_type class_infos
+
+and class_type_declaration = class_type class_infos
+
+(* Value expressions for the class language *)
+
+and class_expr =
+    {
+     pcl_desc: class_expr_desc;
+     pcl_loc: Location.t;
+     pcl_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and class_expr_desc =
+  | Pcl_constr of Longident.t loc * core_type list
+        (* c
+           ['a1, ..., 'an] c *)
+  | Pcl_structure of class_structure
+        (* object ... end *)
+  | Pcl_fun of arg_label * expression option * pattern * class_expr
+        (* fun P -> CE                          (Simple, None)
+           fun ~l:P -> CE                       (Labelled l, None)
+           fun ?l:P -> CE                       (Optional l, None)
+           fun ?l:(P = E0) -> CE                (Optional l, Some E0)
+         *)
+  | Pcl_apply of class_expr * (arg_label * expression) list
+        (* CE ~l1:E1 ... ~ln:En
+           li can be empty (non labeled argument) or start with '?'
+           (optional argument).
+
+           Invariant: n > 0
+         *)
+  | Pcl_let of rec_flag * value_binding list * class_expr
+        (* let P1 = E1 and ... and Pn = EN in CE      (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN in CE  (flag = Recursive)
+         *)
+  | Pcl_constraint of class_expr * class_type
+        (* (CE : CT) *)
+  | Pcl_extension of extension
+  (* [%id] *)
+  | Pcl_open of override_flag * Longident.t loc * class_expr
+  (* let open M in CE *)
+
+
+and class_structure =
+    {
+     pcstr_self: pattern;
+     pcstr_fields: class_field list;
+    }
+(* object(selfpat) ... end
+   object ... end           (self = Ppat_any)
+ *)
+
+and class_field =
+    {
+     pcf_desc: class_field_desc;
+     pcf_loc: Location.t;
+     pcf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+and class_field_desc =
+  | Pcf_inherit of override_flag * class_expr * string loc option
+        (* inherit CE
+           inherit CE as x
+           inherit! CE
+           inherit! CE as x
+         *)
+  | Pcf_val of (label loc * mutable_flag * class_field_kind)
+        (* val x = E
+           val virtual x: T
+         *)
+  | Pcf_method of (label loc * private_flag * class_field_kind)
+        (* method x = E            (E can be a Pexp_poly)
+           method virtual x: T     (T can be a Ptyp_poly)
+         *)
+  | Pcf_constraint of (core_type * core_type)
+        (* constraint T1 = T2 *)
+  | Pcf_initializer of expression
+        (* initializer E *)
+  | Pcf_attribute of attribute
+        (* [@@@id] *)
+  | Pcf_extension of extension
+        (* [%%id] *)
+
+and class_field_kind =
+  | Cfk_virtual of core_type
+  | Cfk_concrete of override_flag * expression
+
+and class_declaration = class_expr class_infos
+
+(** {1 Module language} *)
+
+(* Type expressions for the module language *)
+
+and module_type =
+    {
+     pmty_desc: module_type_desc;
+     pmty_loc: Location.t;
+     pmty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_type_desc =
+  | Pmty_ident of Longident.t loc
+        (* S *)
+  | Pmty_signature of signature
+        (* sig ... end *)
+  | Pmty_functor of string loc * module_type option * module_type
+        (* functor(X : MT1) -> MT2 *)
+  | Pmty_with of module_type * with_constraint list
+        (* MT with ... *)
+  | Pmty_typeof of module_expr
+        (* module type of ME *)
+  | Pmty_extension of extension
+        (* [%id] *)
+  | Pmty_alias of Longident.t loc
+        (* (module M) *)
+
+and signature = signature_item list
+
+and signature_item =
+    {
+     psig_desc: signature_item_desc;
+     psig_loc: Location.t;
+    }
+
+and signature_item_desc =
+  | Psig_value of value_description
+        (*
+          val x: T
+          external x: T = "s1" ... "sn"
+         *)
+  | Psig_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Psig_typext of type_extension
+        (* type t1 += ... *)
+  | Psig_exception of extension_constructor
+        (* exception C of T *)
+  | Psig_module of module_declaration
+        (* module X : MT *)
+  | Psig_recmodule of module_declaration list
+        (* module rec X1 : MT1 and ... and Xn : MTn *)
+  | Psig_modtype of module_type_declaration
+        (* module type S = MT
+           module type S *)
+  | Psig_open of open_description
+        (* open X *)
+  | Psig_include of include_description
+        (* include MT *)
+  | Psig_class of class_description list
+        (* class c1 : ... and ... and cn : ... *)
+  | Psig_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Psig_attribute of attribute
+        (* [@@@id] *)
+  | Psig_extension of extension * attributes
+        (* [%%id] *)
+
+and module_declaration =
+    {
+     pmd_name: string loc;
+     pmd_type: module_type;
+     pmd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmd_loc: Location.t;
+    }
+(* S : MT *)
+
+and module_type_declaration =
+    {
+     pmtd_name: string loc;
+     pmtd_type: module_type option;
+     pmtd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+     pmtd_loc: Location.t;
+    }
+(* S = MT
+   S       (abstract module type declaration, pmtd_type = None)
+*)
+
+and open_description =
+    {
+     popen_lid: Longident.t loc;
+     popen_override: override_flag;
+     popen_loc: Location.t;
+     popen_attributes: attributes;
+    }
+(* open! X - popen_override = Override (silences the 'used identifier
+                              shadowing' warning)
+   open  X - popen_override = Fresh
+ *)
+
+and 'a include_infos =
+    {
+     pincl_mod: 'a;
+     pincl_loc: Location.t;
+     pincl_attributes: attributes;
+    }
+
+and include_description = module_type include_infos
+(* include MT *)
+
+and include_declaration = module_expr include_infos
+(* include ME *)
+
+and with_constraint =
+  | Pwith_type of Longident.t loc * type_declaration
+        (* with type X.t = ...
+
+           Note: the last component of the longident must match
+           the name of the type_declaration. *)
+  | Pwith_module of Longident.t loc * Longident.t loc
+        (* with module X.Y = Z *)
+  | Pwith_typesubst of Longident.t loc * type_declaration
+        (* with type X.t := ..., same format as [Pwith_type] *)
+  | Pwith_modsubst of Longident.t loc * Longident.t loc
+        (* with module X.Y := Z *)
+
+(* Value expressions for the module language *)
+
+and module_expr =
+    {
+     pmod_desc: module_expr_desc;
+     pmod_loc: Location.t;
+     pmod_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+and module_expr_desc =
+  | Pmod_ident of Longident.t loc
+        (* X *)
+  | Pmod_structure of structure
+        (* struct ... end *)
+  | Pmod_functor of string loc * module_type option * module_expr
+        (* functor(X : MT1) -> ME *)
+  | Pmod_apply of module_expr * module_expr
+        (* ME1(ME2) *)
+  | Pmod_constraint of module_expr * module_type
+        (* (ME : MT) *)
+  | Pmod_unpack of expression
+        (* (val E) *)
+  | Pmod_extension of extension
+        (* [%id] *)
+
+and structure = structure_item list
+
+and structure_item =
+    {
+     pstr_desc: structure_item_desc;
+     pstr_loc: Location.t;
+    }
+
+and structure_item_desc =
+  | Pstr_eval of expression * attributes
+        (* E *)
+  | Pstr_value of rec_flag * value_binding list
+        (* let P1 = E1 and ... and Pn = EN       (flag = Nonrecursive)
+           let rec P1 = E1 and ... and Pn = EN   (flag = Recursive)
+         *)
+  | Pstr_primitive of value_description
+        (*  val x: T
+            external x: T = "s1" ... "sn" *)
+  | Pstr_type of rec_flag * type_declaration list
+        (* type t1 = ... and ... and tn = ... *)
+  | Pstr_typext of type_extension
+        (* type t1 += ... *)
+  | Pstr_exception of extension_constructor
+        (* exception C of T
+           exception C = M.X *)
+  | Pstr_module of module_binding
+        (* module X = ME *)
+  | Pstr_recmodule of module_binding list
+        (* module rec X1 = ME1 and ... and Xn = MEn *)
+  | Pstr_modtype of module_type_declaration
+        (* module type S = MT *)
+  | Pstr_open of open_description
+        (* open X *)
+  | Pstr_class of class_declaration list
+        (* class c1 = ... and ... and cn = ... *)
+  | Pstr_class_type of class_type_declaration list
+        (* class type ct1 = ... and ... and ctn = ... *)
+  | Pstr_include of include_declaration
+        (* include ME *)
+  | Pstr_attribute of attribute
+        (* [@@@id] *)
+  | Pstr_extension of extension * attributes
+        (* [%%id] *)
+
+and value_binding =
+  {
+    pvb_pat: pattern;
+    pvb_expr: expression;
+    pvb_attributes: attributes;
+    pvb_loc: Location.t;
+  }
+
+and module_binding =
+    {
+     pmb_name: string loc;
+     pmb_expr: module_expr;
+     pmb_attributes: attributes;
+     pmb_loc: Location.t;
+    }
+(* X = ME *)
+
+(** {1 Toplevel} *)
+
+(* Toplevel phrases *)
+
+type toplevel_phrase =
+  | Ptop_def of structure
+  | Ptop_dir of string * directive_argument
+     (* #use, #load ... *)
+
+and directive_argument =
+  | Pdir_none
+  | Pdir_string of string
+  | Pdir_int of string * char option
+  | Pdir_ident of Longident.t
+  | Pdir_bool of bool
+end
+
+
+
+(* ---- @tracked rewriter --------------------------------------------------
+   Expands the @tracked attribute into the runtime hook it desugars to:
+
+     @tracked([a, b])   ->   SignalsReactAuto.useSignals([
+     <body>                    SignalsReactAuto.dep(a), SignalsReactAuto.dep(b)]);
+                             <body>
+
+     @tracked()         ->   SignalsReactAuto.useTracked(() => <body>)
+     <body>
+
+   The explicit list subscribes to the given signals; the bare form tracks
+   automatically (any Signal.get read inside <body> subscribes). *)
+open Asttypes
+open Parsetree
+
+let none : Location.t =
+  { Location.loc_start = Lexing.dummy_pos; loc_end = Lexing.dummy_pos; loc_ghost = true }
+let mkloc (txt : 'a) : 'a Location.loc = { Location.txt; loc = none }
+let mkexp d = { pexp_desc = d; pexp_loc = none; pexp_attributes = [] }
+let ident lid = mkexp (Pexp_ident (mkloc lid))
+let sra x = Longident.Ldot (Longident.Lident "SignalsReactAuto", x)
+let apply f args = mkexp (Pexp_apply (f, List.map (fun a -> (Nolabel, a)) args))
+let dep_call e = apply (ident (sra "dep")) [ e ]
+let use_signals args = apply (ident (sra "useSignals")) [ mkexp (Pexp_array (List.map dep_call args)) ]
+let seq a b = mkexp (Pexp_sequence (a, b))
+
+(* An uncurried function of arity N is encoded in ReScript's 4.06 ppx AST as
+   `Function$(fun ... -> ...)` with a `res.arity` attribute on the construct
+   (see ast_mapper_from0.ml). A bare Pexp_fun would be imported as curried. *)
+let res_arity n : attribute =
+  let e = mkexp (Pexp_constant (Pconst_integer (string_of_int n, None))) in
+  (mkloc "res.arity", PStr [ { pstr_desc = Pstr_eval (e, []); pstr_loc = none } ])
+let unit_pat =
+  { ppat_desc = Ppat_construct (mkloc (Longident.Lident "()"), None);
+    ppat_loc = none; ppat_attributes = [] }
+let thunk body =
+  let fn = mkexp (Pexp_fun (Nolabel, None, unit_pat, body)) in
+  { pexp_desc = Pexp_construct (mkloc (Longident.Lident "Function$"), Some fn);
+    pexp_loc = none; pexp_attributes = [ res_arity 1 ] }
+let use_tracked body = apply (ident (sra "useTracked")) [ thunk body ]
+
+let is_tracked ((name, _) : attribute) = name.Location.txt = "tracked"
+let strip_tracked = List.filter (fun a -> not (is_tracked a))
+let is_unit e = match e.pexp_desc with
+  | Pexp_construct ({ Location.txt = Longident.Lident "()" }, None) -> true
+  | _ -> false
+
+let rec map_expr (e : expression) : expression =
+  match List.find_opt is_tracked e.pexp_attributes with
+  | Some (_, payload) ->
+    let inner = map_children { e with pexp_attributes = strip_tracked e.pexp_attributes } in
+    (match payload with
+     (* @tracked / @tracked() -> automatic discovery *)
+     | PStr [] -> use_tracked inner
+     | PStr [ { pstr_desc = Pstr_eval (arg, _); _ } ] when is_unit arg -> use_tracked inner
+     (* @tracked([a, b]) / @tracked((a, b)) / @tracked(a) -> explicit list *)
+     | PStr [ { pstr_desc = Pstr_eval (arg, _); _ } ] ->
+       let args = (match arg.pexp_desc with Pexp_tuple xs | Pexp_array xs -> xs | _ -> [ arg ]) in
+       seq (use_signals args) inner
+     | _ -> use_tracked inner)
+  | None -> map_children e
+
+and map_children (e : expression) : expression =
+  let d =
+    match e.pexp_desc with
+    | Pexp_fun (l, def, p, body) -> Pexp_fun (l, def, p, map_expr body)
+    | Pexp_let (r, vbs, body) -> Pexp_let (r, List.map map_vb vbs, map_expr body)
+    | Pexp_sequence (a, b) -> Pexp_sequence (map_expr a, map_expr b)
+    | Pexp_apply (f, args) -> Pexp_apply (map_expr f, List.map (fun (l, a) -> (l, map_expr a)) args)
+    | Pexp_ifthenelse (c, t, eo) -> Pexp_ifthenelse (map_expr c, map_expr t, Option.map map_expr eo)
+    | Pexp_constraint (x, t) -> Pexp_constraint (map_expr x, t)
+    | Pexp_open (o, l, x) -> Pexp_open (o, l, map_expr x)
+    | Pexp_tuple xs -> Pexp_tuple (List.map map_expr xs)
+    | Pexp_array xs -> Pexp_array (List.map map_expr xs)
+    | Pexp_construct (l, eo) -> Pexp_construct (l, Option.map map_expr eo)
+    | other -> other
+  in
+  { e with pexp_desc = d }
+
+and map_vb (vb : value_binding) : value_binding = { vb with pvb_expr = map_expr vb.pvb_expr }
+
+let rec map_structure s = List.map map_si s
+and map_si si =
+  match si.pstr_desc with
+  | Pstr_value (r, vbs) -> { si with pstr_desc = Pstr_value (r, List.map map_vb vbs) }
+  | Pstr_module mb -> { si with pstr_desc = Pstr_module (map_mb mb) }
+  | _ -> si
+and map_mb mb = { mb with pmb_expr = map_mod mb.pmb_expr }
+and map_mod me =
+  match me.pmod_desc with
+  | Pmod_structure s -> { me with pmod_desc = Pmod_structure (map_structure s) }
+  | _ -> me
+
+(* ---- ReScript -ppx binary protocol: `ppx <infile> <outfile>` ------------
+   Files are `<magic><marshaled input_name><marshaled ast>`. ReScript 12 hands
+   ppx an OCaml 4.06 parsetree (magic Caml1999M022); interfaces pass through. *)
+let impl_magic = "Caml1999M022"
+let () =
+  let n = Array.length Sys.argv in
+  let infile = Sys.argv.(n - 2) and outfile = Sys.argv.(n - 1) in
+  let ic = open_in_bin infile in
+  let magic = really_input_string ic (String.length impl_magic) in
+  let name : string = input_value ic in
+  let payload : Obj.t = input_value ic in
+  close_in ic;
+  let oc = open_out_bin outfile in
+  output_string oc magic;
+  output_value oc name;
+  (if magic = impl_magic then output_value oc (map_structure (Obj.magic payload : structure))
+   else output_value oc payload);
+  close_out oc


### PR DESCRIPTION
## Summary

Improves the ergonomics of using signals inside React components while preserving the library's two guarantees — **plain-value reads** and **concurrent-mode / StrictMode safety** via `useSyncExternalStore`. Adds one core primitive, three ways to consume signals in components, and a native PPX for the `@tracked` annotation.

## What's included

**Core — `Signals.Tracking` (notify-only observer)**
A framework-agnostic reactive scope for externally-driven consumers (a UI render). Unlike an `Effect`, it is *notified* on a dependency change rather than recomputed; the driver re-establishes deps via `Tracking.track`. Costs one bitwise flag check per flushed effect on the hot path. `Core`/`Scheduler` stay package-private.

**React — three surfaces (in `SignalsReactAuto`)**
There is one underlying engine (`useTracked`, built on the `Tracking` scope); the other two are a wrapper and compile-time sugar over it.

- `useTracked(() => …)` — automatic discovery: subscribes to whatever the render body reads. Single-pass (the display render *is* the tracking pass), re-discovers deps each render (conditional reads work), no stale props.
- `useSignals([dep(a), dep(b)])` — explicit dependency list; read signals with plain `Signal.get`. Implemented as `useTracked` over a thunk that reads the listed deps.
- `@tracked` — an annotation that the PPX erases at compile time into one of the above:
  - `@tracked([a, b])` → `useSignals([dep(a), dep(b)])`
  - `@tracked()` (or bare `@tracked`) → `useTracked(() => <body>)`

**`rescript-tracked-ppx` (native PPX)**
~1000 lines of OCaml, no opam/dune. Vendors ReScript 12's PPX parsetree (OCaml 4.06, `Caml1999M022`) so `Marshal` round-trips faithfully, implements the `ppx <infile> <outfile>` protocol, and rewrites the `tracked` attribute. The bare form emits `Function$(fun () => …)` with a `res.arity` attribute — the encoding ReScript uses for uncurried functions in the ppx AST (a plain `Pexp_fun` would import as curried). Built with `ocamlopt`, wired via `ppx-flags`.

## Usage

```rescript
// explicit list
@react.component
let make = (~a, ~b, ~c) => {
  @tracked([a, b])
  <div> {React.string(Int.toString(Signal.get(a) + Signal.get(b)))} {React.string(c)} </div>
}

// automatic discovery
@react.component
let make = (~x) => {
  @tracked()
  <div> {React.string(Int.toString(Signal.get(x) * 2))} </div>
}
```

## Choosing between them

| | Subscribes to | Footgun |
|---|---|---|
| `useTracked` / `@tracked()` | whatever the body reads (dynamic) | none — reads *are* the subscription |
| `useSignals` / `@tracked([a, b])` | exactly the listed deps | a read not in the list won't re-render (dep-array style) |

`useTracked` tracks during render (reconciling the scope's dep set); a render discarded by concurrent React is corrected by the committed render, and `useSyncExternalStore` still guards tearing.

## Notes

- `@tracked([a, b])` uses array syntax; `@tracked(a, b)` is a ReScript parse error (the PPX runs after parsing).
- **Build requires OCaml** (`ocamlopt`) to compile the PPX. CI installs `ocaml-nox`; the same is needed for local `npm run build`/`test`.
- The new React APIs live in an experimental `SignalsReactAuto` module, leaving the stable `SignalsReact` surface untouched.

