### PR TITLE
fix: detach computeds when they lose subscribers

### DIFF
--- a/docs-website/src/pages/Pages__ApiComputed.res
+++ b/docs-website/src/pages/Pages__ApiComputed.res
@@ -20,7 +20,7 @@ let make = () => {
     </div>
     <Typography
       text={static(
-        "Creates a computed value from a function. The function is called lazily and cached until a dependency changes.",
+        "Creates a computed value from a function. The function runs once to establish dependencies, then the value is cached until a dependency changes.",
       )}
     />
     <CodeBlock
@@ -85,14 +85,19 @@ Computed.get(quadrupled) // 20`}
     </div>
     <Typography
       text={static(
-        "Manually disposes a computed, removing all subscriptions. The computed will no longer track dependencies.",
+        "A computed subscribes to its sources only while something is subscribed to it, and detaches on its own once its last subscriber goes away. Dropping a computed you never subscribed to is enough — no cleanup call is needed.",
+      )}
+    />
+    <Typography
+      text={static(
+        "Computed.dispose detaches a computed that is still subscribed. It stays usable: the next read rebuilds its dependencies.",
       )}
     />
     <CodeBlock
       language="rescript"
       code={`let computed = Computed.make(() => Signal.get(count) * 2)
 
-// Later, when no longer needed
+// Only needed to detach a computed that still has subscribers
 Computed.dispose(computed)`}
     />
     <Separator />
@@ -101,8 +106,8 @@ Computed.dispose(computed)`}
       <a class="anchor-link" href="#key-characteristics"> {"#"->Component.text} </a>
     </div>
     <ul style="line-height: 1.8; color: var(--basefn-text-secondary);">
-      <li> <strong> {"Lazy Evaluation"->Component.text} </strong> {" — Computed values are not calculated until they are first read. This avoids unnecessary computation."->Component.text} </li>
       <li> <strong> {"Automatic Caching"->Component.text} </strong> {" — Once calculated, the value is cached until a dependency changes. Multiple reads return the cached value."->Component.text} </li>
+      <li> <strong> {"Self-Releasing"->Component.text} </strong> {" — A computed attaches to its sources only while it has subscribers, and detaches when the last one goes away. Deriving values inline is safe: a computed you drop keeps nothing alive and costs its sources nothing on write."->Component.text} </li>
       <li> <strong> {"Dependency Tracking"->Component.text} </strong> {" — Dependencies are automatically tracked when Signal.get() or Computed.get() is called inside the computation function."->Component.text} </li>
       <li> <strong> {"Glitch-Free"->Component.text} </strong> {" — Updates are batched and computed values are recalculated in topological order to prevent intermediate inconsistent states."->Component.text} </li>
     </ul>

--- a/packages/rescript-signals/README.md
+++ b/packages/rescript-signals/README.md
@@ -63,7 +63,7 @@ Signal.update(count, n => n + 1) // Update based on current value
 
 ### Computed
 
-Derived reactive values that update automatically. Computed values are lazily evaluated and cached until their dependencies change.
+Derived reactive values that update automatically. Computed values are cached until one of their dependencies changes.
 
 ```rescript
 let firstName = Signal.make("Ada")
@@ -73,6 +73,19 @@ let fullName = Computed.make(() =>
   Signal.get(firstName) ++ " " ++ Signal.get(lastName)
 )
 ```
+
+A computed subscribes to its sources only while something is subscribed to it, and
+detaches once its last subscriber goes away. That makes it safe to derive values
+inline — in a render function, a helper, or anywhere called repeatedly:
+
+```rescript
+let label = (value: Signal.t<int>) =>
+  Computed.make(() => Signal.get(value)->Int.toString)
+```
+
+A computed you create and drop holds nothing open and adds no cost to writes on its
+sources. `Computed.dispose` exists to detach one that still has subscribers; it stays
+usable afterwards, since the next read rebuilds its dependencies.
 
 ### Effect
 

--- a/packages/rescript-signals/src/signals/Computed.res
+++ b/packages/rescript-signals/src/signals/Computed.res
@@ -106,6 +106,12 @@ let make = (
   | None => makeWithoutEquals(compute, ~name?)
   }
 
+// Computeds detach from their sources on their own once they lose their last
+// subscriber, so this is only needed to release one that is still subscribed.
+// The computed stays usable: the next read rebuilds its dependencies.
 let dispose = (signal: Signal.t<'a>): unit => {
-  Core.clearSubsDeps(signal.subs)
+  let subs = signal.subs
+  Core.clearSubsDeps(subs)
+  Core.clearLinked(subs)
+  Core.setSubsDirty(subs)
 }

--- a/packages/rescript-signals/src/signals/Computed.res
+++ b/packages/rescript-signals/src/signals/Computed.res
@@ -112,6 +112,6 @@ let make = (
 let dispose = (signal: Signal.t<'a>): unit => {
   let subs = signal.subs
   Core.clearSubsDeps(subs)
-  Core.clearLinked(subs)
+  Core.markDetached(subs)
   Core.setSubsDirty(subs)
 }

--- a/packages/rescript-signals/src/signals/Core.res
+++ b/packages/rescript-signals/src/signals/Core.res
@@ -5,9 +5,13 @@
 let flag_dirty = 1
 let flag_pending = 2
 let flag_running = 4
-// Set on a computed while it is attached to its own sources ("hot").
-// A computed is hot exactly while it has at least one subscriber.
-let flag_linked = 8
+// Set on a computed while it is detached from its own sources.
+// A computed is attached exactly while it has at least one subscriber.
+// Stored as "detached" rather than "attached" so that a settled computed carries
+// none of these bits, letting a read test dirty and detached in one mask.
+let flag_detached = 8
+// A computed with neither bit set is attached and clean: its cached value stands.
+let flag_needs_settle = 9
 
 // Global tracking version
 let trackingVersion: ref<int> = ref(0)
@@ -104,7 +108,7 @@ let makeComputedSubs = (compute: unit => unit, ~deferEffectsUntilRecompute: bool
   compute: Some(compute),
   firstDep: None,
   lastDep: None,
-  flags: flag_dirty, // start dirty
+  flags: Int.bitwiseOr(flag_dirty, flag_detached), // start dirty and detached
   level: 0,
   deferEffectsUntilRecompute,
   lastGlobalVersion: 0,
@@ -149,11 +153,11 @@ let setSubsPending = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_pe
 let clearSubsPending = (s: subs): unit =>
   s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_pending))
 
-// Whether a computed is currently attached to its sources
-let isLinked = (s: subs): bool => Int.bitwiseAnd(s.flags, flag_linked) !== 0
-let setLinked = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_linked)
-let clearLinked = (s: subs): unit =>
-  s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_linked))
+// Whether a computed is currently detached from its sources
+let isDetached = (s: subs): bool => Int.bitwiseAnd(s.flags, flag_detached) !== 0
+let markDetached = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_detached)
+let markAttached = (s: subs): unit =>
+  s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_detached))
 
 // Check if subs is a computed
 let isComputed = (s: subs): bool => s.compute !== None
@@ -194,7 +198,7 @@ let rec linkToSubs = (subs: subs, link: link): unit => {
       subs.computedSubscriberCount = subs.computedSubscriberCount + 1
     }
 
-    if wasEmpty && isComputed(subs) && !isLinked(subs) {
+    if wasEmpty && isComputed(subs) && isDetached(subs) {
       attachToSources(subs)
     }
   }
@@ -207,8 +211,8 @@ let rec linkToSubs = (subs: subs, link: link): unit => {
 // treats the dirty flag as its "already propagated" marker, so a computed dirtied
 // out of band swallows later notifications instead of passing them downstream.
 and attachToSources = (s: subs): unit => {
-  // Set first: guards against re-entering through the recursive linkToSubs below.
-  setLinked(s)
+  // Clear first: guards against re-entering through the recursive linkToSubs below.
+  markAttached(s)
 
   let link = ref(s.firstDep)
   while link.contents !== None {
@@ -257,7 +261,7 @@ let rec unlinkFromSubs = (link: link): unit => {
       subs.computedSubscriberCount = subs.computedSubscriberCount - 1
     }
 
-    if subs.first === None && isComputed(subs) && isLinked(subs) {
+    if subs.first === None && isComputed(subs) && !isDetached(subs) {
       detachFromSources(subs)
     }
   }
@@ -266,8 +270,8 @@ let rec unlinkFromSubs = (link: link): unit => {
 // Detach a computed from every source in its dependency chain.
 // The chain itself is preserved, so the computed can go hot again later.
 and detachFromSources = (s: subs): unit => {
-  // Clear first: guards against re-entering through the recursive unlink below.
-  clearLinked(s)
+  // Set first: guards against re-entering through the recursive unlink below.
+  markDetached(s)
 
   let link = ref(s.firstDep)
   while link.contents !== None {

--- a/packages/rescript-signals/src/signals/Core.res
+++ b/packages/rescript-signals/src/signals/Core.res
@@ -5,6 +5,9 @@
 let flag_dirty = 1
 let flag_pending = 2
 let flag_running = 4
+// Set on a computed while it is attached to its own sources ("hot").
+// A computed is hot exactly while it has at least one subscriber.
+let flag_linked = 8
 
 // Global tracking version
 let trackingVersion: ref<int> = ref(0)
@@ -27,6 +30,12 @@ module rec Link: {
     mutable prevSub: option<Link.t>,
     // Version stamp for duplicate detection within a compute cycle
     mutable lastTrackedVersion: int,
+    // Source's subs.version when this dependency was last read. Lets a cold
+    // computed decide whether it is stale without receiving notifications.
+    mutable lastSourceVersion: int,
+    // Whether this link currently sits in the source's subscriber chain.
+    // A cold computed keeps its dependency chain but detaches every link.
+    mutable attached: bool,
   }
 } = Link
 
@@ -140,6 +149,12 @@ let setSubsPending = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_pe
 let clearSubsPending = (s: subs): unit =>
   s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_pending))
 
+// Whether a computed is currently attached to its sources
+let isLinked = (s: subs): bool => Int.bitwiseAnd(s.flags, flag_linked) !== 0
+let setLinked = (s: subs): unit => s.flags = Int.bitwiseOr(s.flags, flag_linked)
+let clearLinked = (s: subs): unit =>
+  s.flags = Int.bitwiseAnd(s.flags, Int.bitwiseNot(flag_linked))
+
 // Check if subs is a computed
 let isComputed = (s: subs): bool => s.compute !== None
 
@@ -153,22 +168,57 @@ let makeLink = (sourceSubs: subs, linkedObserver: observer): link => {
     nextSub: None,
     prevSub: None,
     lastTrackedVersion: 0,
+    lastSourceVersion: -1,
+    attached: false,
   }
 }
 
-// Add link to signal's subscriber list
-let linkToSubs = (subs: subs, link: link): unit => {
-  link.prevSub = subs.last
-  link.nextSub = None
-  switch subs.last {
-  | Some(last) => last.nextSub = Some(link)
-  | None => subs.first = Some(link)
-  }
-  subs.last = Some(link)
+// Add link to signal's subscriber list.
+// If this is the first subscriber of a cold computed, that computed goes hot:
+// it re-attaches to its own sources so notifications can reach it again.
+let rec linkToSubs = (subs: subs, link: link): unit => {
+  if !link.attached {
+    link.attached = true
+    let wasEmpty = subs.first === None
 
-  let linkedSubs = (Obj.magic(link.observer): subs)
-  if isComputed(linkedSubs) {
-    subs.computedSubscriberCount = subs.computedSubscriberCount + 1
+    link.prevSub = subs.last
+    link.nextSub = None
+    switch subs.last {
+    | Some(last) => last.nextSub = Some(link)
+    | None => subs.first = Some(link)
+    }
+    subs.last = Some(link)
+
+    let linkedSubs = (Obj.magic(link.observer): subs)
+    if isComputed(linkedSubs) {
+      subs.computedSubscriberCount = subs.computedSubscriberCount + 1
+    }
+
+    if wasEmpty && isComputed(subs) && !isLinked(subs) {
+      attachToSources(subs)
+    }
+  }
+}
+
+// Re-attach a computed to every source in its dependency chain.
+// The value needs no reconciliation here: attaching only ever happens from inside
+// Signal.get, which settles freshness before tracking, so a computed going hot is
+// already up to date. Marking it dirty would also be actively wrong - notifySubs
+// treats the dirty flag as its "already propagated" marker, so a computed dirtied
+// out of band swallows later notifications instead of passing them downstream.
+and attachToSources = (s: subs): unit => {
+  // Set first: guards against re-entering through the recursive linkToSubs below.
+  setLinked(s)
+
+  let link = ref(s.firstDep)
+  while link.contents !== None {
+    switch link.contents {
+    | Some(l) =>
+      let next = l.nextDep
+      linkToSubs(l.subs, l)
+      link := next
+    | None => ()
+    }
   }
 }
 
@@ -183,23 +233,51 @@ let linkToDeps = (observer: observer, link: link): unit => {
   observer.lastDep = Some(link)
 }
 
-// Remove link from subscriber list
-let unlinkFromSubs = (link: link): unit => {
-  let subs = link.subs
-  switch link.prevSub {
-  | Some(prev) => prev.nextSub = link.nextSub
-  | None => subs.first = link.nextSub
-  }
-  switch link.nextSub {
-  | Some(next) => next.prevSub = link.prevSub
-  | None => subs.last = link.prevSub
-  }
-  link.prevSub = None
-  link.nextSub = None
+// Remove link from subscriber list.
+// If this was the last subscriber of a computed, that computed goes cold:
+// it detaches from its own sources so neither it nor its cached value keeps
+// them alive, and so writes stop paying to walk over it.
+let rec unlinkFromSubs = (link: link): unit => {
+  if link.attached {
+    link.attached = false
+    let subs = link.subs
+    switch link.prevSub {
+    | Some(prev) => prev.nextSub = link.nextSub
+    | None => subs.first = link.nextSub
+    }
+    switch link.nextSub {
+    | Some(next) => next.prevSub = link.prevSub
+    | None => subs.last = link.prevSub
+    }
+    link.prevSub = None
+    link.nextSub = None
 
-  let linkedSubs = (Obj.magic(link.observer): subs)
-  if isComputed(linkedSubs) && subs.computedSubscriberCount > 0 {
-    subs.computedSubscriberCount = subs.computedSubscriberCount - 1
+    let linkedSubs = (Obj.magic(link.observer): subs)
+    if isComputed(linkedSubs) && subs.computedSubscriberCount > 0 {
+      subs.computedSubscriberCount = subs.computedSubscriberCount - 1
+    }
+
+    if subs.first === None && isComputed(subs) && isLinked(subs) {
+      detachFromSources(subs)
+    }
+  }
+}
+
+// Detach a computed from every source in its dependency chain.
+// The chain itself is preserved, so the computed can go hot again later.
+and detachFromSources = (s: subs): unit => {
+  // Clear first: guards against re-entering through the recursive unlink below.
+  clearLinked(s)
+
+  let link = ref(s.firstDep)
+  while link.contents !== None {
+    switch link.contents {
+    | Some(l) =>
+      let next = l.nextDep
+      unlinkFromSubs(l)
+      link := next
+    | None => ()
+    }
   }
 }
 

--- a/packages/rescript-signals/src/signals/Scheduler.res
+++ b/packages/rescript-signals/src/signals/Scheduler.res
@@ -71,12 +71,17 @@ let addComputedToPending = (subs: Core.subs): unit => {
 // Track a dependency from a computed (subs tracks subs)
 let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): unit => {
   let computedObserver: Core.observer = Obj.magic(computedSubs)
+  // A cold computed records what it depends on but does not attach to it.
+  let isHot = Core.isLinked(computedSubs)
 
   if computedSubs.firstDep === None {
     let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
     newLink.lastTrackedVersion = currentTrackingVersion.contents
+    newLink.lastSourceVersion = sourceSubs.version
     Core.linkToSubsDeps(computedSubs, newLink)
-    Core.linkToSubs(sourceSubs, newLink)
+    if isHot {
+      Core.linkToSubs(sourceSubs, newLink)
+    }
     currentComputedDepCursor := Some(newLink)
   } else {
     let currentVersion = currentTrackingVersion.contents
@@ -86,12 +91,14 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
     | Some(cursor) =>
       if cursor.subs === sourceSubs && cursor.observer === computedObserver {
         cursor.lastTrackedVersion = currentVersion
+        cursor.lastSourceVersion = sourceSubs.version
         fastPathFound.contents = true
       } else {
         switch cursor.nextDep {
         | Some(nextDep) =>
           if nextDep.subs === sourceSubs && nextDep.observer === computedObserver {
             nextDep.lastTrackedVersion = currentVersion
+            nextDep.lastSourceVersion = sourceSubs.version
             currentComputedDepCursor := Some(nextDep)
             fastPathFound.contents = true
           }
@@ -106,6 +113,7 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
       | Some(lastSubLink) =>
         if lastSubLink.lastTrackedVersion === currentVersion && lastSubLink.observer === computedObserver {
           lastSubLink.lastTrackedVersion = currentVersion
+          lastSubLink.lastSourceVersion = sourceSubs.version
           currentComputedDepCursor := Some(lastSubLink)
           fastPathFound.contents = true
         }
@@ -123,6 +131,7 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
         | Some(l) =>
           if l.subs === sourceSubs {
             l.lastTrackedVersion = currentVersion
+            l.lastSourceVersion = sourceSubs.version
             foundLink := Some(l)
             found := true
           } else {
@@ -136,8 +145,11 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
       if !found.contents {
         let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
         newLink.lastTrackedVersion = currentVersion
+        newLink.lastSourceVersion = sourceSubs.version
         Core.linkToSubsDeps(computedSubs, newLink)
-        Core.linkToSubs(sourceSubs, newLink)
+        if isHot {
+          Core.linkToSubs(sourceSubs, newLink)
+        }
         currentComputedDepCursor := Some(newLink)
       } else {
         currentComputedDepCursor := foundLink.contents
@@ -554,23 +566,60 @@ let notifySubs = (subs: Core.subs): unit => {
   }
 }
 
+let recomputeAndLevel = (subs: Core.subs): unit => {
+  let oldLevel = subs.level
+  runComputedCycle(subs, ~clearPending=false)
+
+  if oldLevel == 0 {
+    subs.level = computeSubsLevel(subs)
+  }
+}
+
 // Ensure a computed signal is fresh before reading (with link reuse)
-let ensureComputedFresh = (subs: Core.subs): unit => {
+let rec ensureComputedFresh = (subs: Core.subs): unit => {
   if Core.isComputed(subs) {
     if Core.isSubsDirty(subs) {
-      // Dirty without a newer global write means stale dirty flag only.
-      if subs.lastGlobalVersion === Core.globalVersion.contents {
+      // Hot computeds are attached to their sources, so notifications reach them
+      // and a set dirty flag is authoritative. Cold ones are told the same way
+      // when they are marked before detaching, or have never been computed.
+      if Core.isLinked(subs) && subs.lastGlobalVersion === Core.globalVersion.contents {
+        // Dirty without a newer global write means stale dirty flag only.
         Core.clearSubsDirty(subs)
       } else {
-        let oldLevel = subs.level
-        runComputedCycle(subs, ~clearPending=false)
-
-        if oldLevel == 0 {
-          subs.level = computeSubsLevel(subs)
-        }
+        recomputeAndLevel(subs)
+      }
+    } else if !Core.isLinked(subs) && subs.lastGlobalVersion !== Core.globalVersion.contents {
+      // Cold: nothing notified this computed, so being un-dirty proves nothing.
+      // No write anywhere since the last compute is the cheap way out; otherwise
+      // compare each source against the version we last read from it.
+      if sourcesChanged(subs) {
+        recomputeAndLevel(subs)
+      } else {
+        // Verified fresh - re-stamp so the next read takes the cheap path.
+        subs.lastGlobalVersion = Core.globalVersion.contents
       }
     }
   }
+}
+
+// Whether any source of a cold computed has moved since it was last read.
+// A source that is itself a cold computed has to be settled first.
+and sourcesChanged = (s: Core.subs): bool => {
+  let changed = ref(false)
+  let link = ref(s.firstDep)
+  while link.contents !== None && !changed.contents {
+    switch link.contents {
+    | Some(l) =>
+      ensureComputedFresh(l.subs)
+      if l.subs.version !== l.lastSourceVersion {
+        changed := true
+      } else {
+        link := l.nextDep
+      }
+    | None => ()
+    }
+  }
+  changed.contents
 }
 
 // Schedule an effect for execution

--- a/packages/rescript-signals/src/signals/Scheduler.res
+++ b/packages/rescript-signals/src/signals/Scheduler.res
@@ -73,6 +73,11 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
   let computedObserver: Core.observer = Obj.magic(computedSubs)
   // A cold computed records what it depends on but does not attach to it.
   let isHot = Core.isLinked(computedSubs)
+  // Only a cold computed reads lastSourceVersion, so a hot one skips maintaining
+  // it - this runs on every dependency read of every recompute, the hottest path
+  // there is. Versions only ever grow, so the stale stamp a computed carries out
+  // of a hot spell can make the first read after it goes cold recompute once too
+  // often, never miss an update.
 
   if computedSubs.firstDep === None {
     let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
@@ -91,14 +96,18 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
     | Some(cursor) =>
       if cursor.subs === sourceSubs && cursor.observer === computedObserver {
         cursor.lastTrackedVersion = currentVersion
-        cursor.lastSourceVersion = sourceSubs.version
+        if !isHot {
+          cursor.lastSourceVersion = sourceSubs.version
+        }
         fastPathFound.contents = true
       } else {
         switch cursor.nextDep {
         | Some(nextDep) =>
           if nextDep.subs === sourceSubs && nextDep.observer === computedObserver {
             nextDep.lastTrackedVersion = currentVersion
-            nextDep.lastSourceVersion = sourceSubs.version
+            if !isHot {
+              nextDep.lastSourceVersion = sourceSubs.version
+            }
             currentComputedDepCursor := Some(nextDep)
             fastPathFound.contents = true
           }
@@ -113,7 +122,9 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
       | Some(lastSubLink) =>
         if lastSubLink.lastTrackedVersion === currentVersion && lastSubLink.observer === computedObserver {
           lastSubLink.lastTrackedVersion = currentVersion
-          lastSubLink.lastSourceVersion = sourceSubs.version
+          if !isHot {
+            lastSubLink.lastSourceVersion = sourceSubs.version
+          }
           currentComputedDepCursor := Some(lastSubLink)
           fastPathFound.contents = true
         }
@@ -131,7 +142,9 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
         | Some(l) =>
           if l.subs === sourceSubs {
             l.lastTrackedVersion = currentVersion
-            l.lastSourceVersion = sourceSubs.version
+            if !isHot {
+              l.lastSourceVersion = sourceSubs.version
+            }
             foundLink := Some(l)
             found := true
           } else {

--- a/packages/rescript-signals/src/signals/Scheduler.res
+++ b/packages/rescript-signals/src/signals/Scheduler.res
@@ -71,20 +71,19 @@ let addComputedToPending = (subs: Core.subs): unit => {
 // Track a dependency from a computed (subs tracks subs)
 let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): unit => {
   let computedObserver: Core.observer = Obj.magic(computedSubs)
-  // A cold computed records what it depends on but does not attach to it.
-  let isHot = Core.isLinked(computedSubs)
-  // Only a cold computed reads lastSourceVersion, so a hot one skips maintaining
-  // it - this runs on every dependency read of every recompute, the hottest path
-  // there is. Versions only ever grow, so the stale stamp a computed carries out
-  // of a hot spell can make the first read after it goes cold recompute once too
-  // often, never miss an update.
+  // Dependency reuse below stays exactly as cheap as it was before detaching
+  // existed: lastSourceVersion is not maintained here at all. Only a detached
+  // computed reads it, and ensureComputedFresh stamps the whole chain right
+  // after a detached recompute, which is O(deps) on a path that already ran the
+  // compute function.
 
   if computedSubs.firstDep === None {
     let newLink: Core.link = Core.makeLink(sourceSubs, computedObserver)
     newLink.lastTrackedVersion = currentTrackingVersion.contents
     newLink.lastSourceVersion = sourceSubs.version
     Core.linkToSubsDeps(computedSubs, newLink)
-    if isHot {
+    // A detached computed records what it depends on but does not attach to it.
+    if !Core.isDetached(computedSubs) {
       Core.linkToSubs(sourceSubs, newLink)
     }
     currentComputedDepCursor := Some(newLink)
@@ -96,18 +95,12 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
     | Some(cursor) =>
       if cursor.subs === sourceSubs && cursor.observer === computedObserver {
         cursor.lastTrackedVersion = currentVersion
-        if !isHot {
-          cursor.lastSourceVersion = sourceSubs.version
-        }
         fastPathFound.contents = true
       } else {
         switch cursor.nextDep {
         | Some(nextDep) =>
           if nextDep.subs === sourceSubs && nextDep.observer === computedObserver {
             nextDep.lastTrackedVersion = currentVersion
-            if !isHot {
-              nextDep.lastSourceVersion = sourceSubs.version
-            }
             currentComputedDepCursor := Some(nextDep)
             fastPathFound.contents = true
           }
@@ -122,9 +115,6 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
       | Some(lastSubLink) =>
         if lastSubLink.lastTrackedVersion === currentVersion && lastSubLink.observer === computedObserver {
           lastSubLink.lastTrackedVersion = currentVersion
-          if !isHot {
-            lastSubLink.lastSourceVersion = sourceSubs.version
-          }
           currentComputedDepCursor := Some(lastSubLink)
           fastPathFound.contents = true
         }
@@ -142,9 +132,6 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
         | Some(l) =>
           if l.subs === sourceSubs {
             l.lastTrackedVersion = currentVersion
-            if !isHot {
-              l.lastSourceVersion = sourceSubs.version
-            }
             foundLink := Some(l)
             found := true
           } else {
@@ -160,7 +147,7 @@ let trackDepFromComputed = (computedSubs: Core.subs, sourceSubs: Core.subs): uni
         newLink.lastTrackedVersion = currentVersion
         newLink.lastSourceVersion = sourceSubs.version
         Core.linkToSubsDeps(computedSubs, newLink)
-        if isHot {
+        if !Core.isDetached(computedSubs) {
           Core.linkToSubs(sourceSubs, newLink)
         }
         currentComputedDepCursor := Some(newLink)
@@ -588,25 +575,47 @@ let recomputeAndLevel = (subs: Core.subs): unit => {
   }
 }
 
-// Ensure a computed signal is fresh before reading (with link reuse)
+// Record where every source stands right now. A detached computed receives no
+// notifications, so these stamps are the only thing that later tells it whether
+// anything actually moved.
+let stampSources = (s: Core.subs): unit => {
+  let link = ref(s.firstDep)
+  while link.contents !== None {
+    switch link.contents {
+    | Some(l) =>
+      l.lastSourceVersion = l.subs.version
+      link := l.nextDep
+    | None => ()
+    }
+  }
+}
+
+// Ensure a computed signal is fresh before reading (with link reuse).
+// Plain signals and settled computeds carry no flags in the mask, so the common
+// read costs a single test - the same as before computeds could detach.
 let rec ensureComputedFresh = (subs: Core.subs): unit => {
-  if Core.isComputed(subs) {
+  if Int.bitwiseAnd(subs.flags, Core.flag_needs_settle) !== 0 && Core.isComputed(subs) {
+    let detached = Core.isDetached(subs)
     if Core.isSubsDirty(subs) {
-      // Hot computeds are attached to their sources, so notifications reach them
-      // and a set dirty flag is authoritative. Cold ones are told the same way
-      // when they are marked before detaching, or have never been computed.
-      if Core.isLinked(subs) && subs.lastGlobalVersion === Core.globalVersion.contents {
+      // An attached computed hears about every write, so a set dirty flag is
+      // authoritative. A detached one is told this way too, when it was marked
+      // before detaching or has never been computed.
+      if !detached && subs.lastGlobalVersion === Core.globalVersion.contents {
         // Dirty without a newer global write means stale dirty flag only.
         Core.clearSubsDirty(subs)
       } else {
         recomputeAndLevel(subs)
+        if detached {
+          stampSources(subs)
+        }
       }
-    } else if !Core.isLinked(subs) && subs.lastGlobalVersion !== Core.globalVersion.contents {
-      // Cold: nothing notified this computed, so being un-dirty proves nothing.
-      // No write anywhere since the last compute is the cheap way out; otherwise
-      // compare each source against the version we last read from it.
+    } else if subs.lastGlobalVersion !== Core.globalVersion.contents {
+      // Detached (the mask left nothing else it could be), so being un-dirty
+      // proves nothing. No write anywhere since the last compute is the cheap
+      // way out; otherwise compare each source against its recorded version.
       if sourcesChanged(subs) {
         recomputeAndLevel(subs)
+        stampSources(subs)
       } else {
         // Verified fresh - re-stamp so the next read takes the cheap path.
         subs.lastGlobalVersion = Core.globalVersion.contents

--- a/packages/rescript-signals/tests/LifecycleTests.res
+++ b/packages/rescript-signals/tests/LifecycleTests.res
@@ -1,0 +1,258 @@
+@@warning("-44")
+open Zekr
+open Signals
+
+// Number of live subscribers attached to a signal. A computed that has detached
+// from its sources leaves no link behind, so this is what the leak tests assert on.
+let subscriberCount = (signal: Signal.t<'a>): int => {
+  let count = ref(0)
+  let link = ref(signal.subs.first)
+  while link.contents !== None {
+    switch link.contents {
+    | Some(l) =>
+      count := count.contents + 1
+      link := l.nextSub
+    | None => ()
+    }
+  }
+  count.contents
+}
+
+let tests = Suite.make(
+  "Computed Lifecycle Tests",
+  [
+    Test.make("computed does not attach to its source until it has a subscriber", () => {
+      let source = Signal.make(1)
+      let _doubled = Computed.make(() => Signal.get(source) * 2)
+
+      Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="An unsubscribed computed should not sit in the source's subscriber list",
+      )
+    }),
+    Test.make("computed attaches while subscribed and detaches afterwards", () => {
+      let source = Signal.make(1)
+      let doubled = Computed.make(() => Signal.get(source) * 2)
+
+      let disposer = Effect.runWithDisposer(() => {
+        let _ = Signal.get(doubled)
+        None
+      })
+
+      let whileSubscribed = Assert.equal(
+        subscriberCount(source),
+        1,
+        ~message="A subscribed computed should be attached to its source",
+      )
+
+      disposer.dispose()
+
+      let afterDisposal = Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="A computed should detach once its last subscriber goes away",
+      )
+
+      Assert.combineResults([whileSubscribed, afterDisposal])
+    }),
+    Test.make("discarded computeds do not accumulate on the source", () => {
+      let source = Signal.make(0)
+
+      for i in 1 to 100 {
+        let _ = Computed.make(() => Signal.get(source) + i)
+      }
+
+      Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="Creating and dropping computeds should leave the source untouched",
+      )
+    }),
+    Test.make("repeated subscribe/unsubscribe cycles do not accumulate", () => {
+      let source = Signal.make(0)
+
+      for _ in 1 to 100 {
+        let derived = Computed.make(() => Signal.get(source) * 2)
+        let disposer = Effect.runWithDisposer(() => {
+          let _ = Signal.get(derived)
+          None
+        })
+        disposer.dispose()
+      }
+
+      Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="Full subscribe/unsubscribe cycles should leave no links behind",
+      )
+    }),
+    Test.make("chained computeds detach transitively", () => {
+      let source = Signal.make(1)
+      let doubled = Computed.make(() => Signal.get(source) * 2)
+      let quadrupled = Computed.make(() => Signal.get(doubled) * 2)
+
+      let disposer = Effect.runWithDisposer(() => {
+        let _ = Signal.get(quadrupled)
+        None
+      })
+
+      let whileSubscribed = Assert.equal(
+        subscriberCount(source),
+        1,
+        ~message="The whole chain should be attached while the tail is subscribed",
+      )
+
+      disposer.dispose()
+
+      let sourceDetached = Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="Detaching should propagate up the chain to the root signal",
+      )
+      let middleDetached = Assert.equal(
+        subscriberCount(doubled),
+        0,
+        ~message="The intermediate computed should have no subscribers left",
+      )
+
+      Assert.combineResults([whileSubscribed, sourceDetached, middleDetached])
+    }),
+    Test.make("detached computed still reads the latest value", () => {
+      let a = Signal.make(1)
+      let b = Signal.make(10)
+      let sum = Computed.make(() => Signal.get(a) + Signal.get(b))
+      let doubled = Computed.make(() => Signal.get(sum) * 2)
+
+      let initial = Assert.equal(Signal.get(doubled), 22, ~message="Initial value should be 22")
+
+      Signal.set(a, 5)
+      let afterFirst = Assert.equal(
+        Signal.get(doubled),
+        30,
+        ~message="A detached computed should still see writes to its source",
+      )
+
+      Signal.set(b, 100)
+      let afterSecond = Assert.equal(
+        Signal.get(doubled),
+        210,
+        ~message="A detached chain should recompute through every level",
+      )
+
+      Assert.combineResults([initial, afterFirst, afterSecond])
+    }),
+    Test.make("detached computed is not recomputed by unrelated writes", () => {
+      let source = Signal.make(1)
+      let unrelated = Signal.make(0)
+      let computeCount = ref(0)
+      let derived = Computed.make(() => {
+        computeCount := computeCount.contents + 1
+        Signal.get(source)
+      })
+
+      let _ = Signal.get(derived)
+      let baseline = computeCount.contents
+
+      Signal.set(unrelated, 1)
+      let _ = Signal.get(derived)
+      let _ = Signal.get(derived)
+
+      Assert.equal(
+        computeCount.contents,
+        baseline,
+        ~message="Writes to an unrelated signal should not force a recompute",
+      )
+    }),
+    Test.make("subscribing after detached writes sees the latest value", () => {
+      let source = Signal.make(1)
+      let doubled = Computed.make(() => Signal.get(source) * 2)
+
+      // Written while nothing is subscribed, so no notification is delivered.
+      Signal.set(source, 21)
+
+      let observed = ref(0)
+      let disposer = Effect.runWithDisposer(() => {
+        observed := Signal.get(doubled)
+        None
+      })
+
+      let onAttach = Assert.equal(
+        observed.contents,
+        42,
+        ~message="Re-attaching should reconcile the value missed while detached",
+      )
+
+      Signal.set(source, 3)
+      let afterAttach = Assert.equal(
+        observed.contents,
+        6,
+        ~message="Updates should propagate normally once re-attached",
+      )
+
+      disposer.dispose()
+      Signal.set(source, 5)
+      let afterDetach = Assert.equal(
+        Signal.get(doubled),
+        10,
+        ~message="Reads should stay correct after detaching again",
+      )
+
+      Assert.combineResults([onAttach, afterAttach, afterDetach])
+    }),
+    Test.make("disposed computed rebuilds itself on the next read", () => {
+      let source = Signal.make(1)
+      let doubled = Computed.make(() => Signal.get(source) * 10)
+
+      let before = Assert.equal(Signal.get(doubled), 10, ~message="Initial value should be 10")
+
+      Computed.dispose(doubled)
+      Signal.set(source, 5)
+
+      let after = Assert.equal(
+        Signal.get(doubled),
+        50,
+        ~message="A disposed computed should recompute rather than report a stale value",
+      )
+
+      Assert.combineResults([before, after])
+    }),
+    Test.make("writes stay correct with many live subscribers", () => {
+      let source = Signal.make(1)
+      let derived = Computed.make(() => Signal.get(source) * 2)
+      let observed = ref([])
+      let disposers = []
+
+      for _ in 1 to 5 {
+        let disposer = Effect.runWithDisposer(() => {
+          observed := observed.contents->Array.concat([Signal.get(derived)])
+          None
+        })
+        disposers->Array.push(disposer)
+      }
+
+      Signal.set(source, 3)
+
+      let attached = Assert.equal(
+        subscriberCount(source),
+        1,
+        ~message="Five subscribers on one computed still means one link to the source",
+      )
+      let value = Assert.equal(
+        Signal.get(derived),
+        6,
+        ~message="Computed should reflect the latest write",
+      )
+
+      disposers->Array.forEach(d => d.dispose())
+
+      let detached = Assert.equal(
+        subscriberCount(source),
+        0,
+        ~message="Source should be free once every subscriber is gone",
+      )
+
+      Assert.combineResults([attached, value, detached])
+    }),
+  ],
+)

--- a/packages/rescript-signals/tests/PropertyTests.res
+++ b/packages/rescript-signals/tests/PropertyTests.res
@@ -1,0 +1,134 @@
+@@warning("-44")
+open Zekr
+open Signals
+
+// Randomized property test over generated graphs, driven by a fixed-seed LCG so
+// every run is reproducible.
+//
+// The property: once an operation has settled, every subscribed effect must have
+// observed the current value of the node it watches. Subscribe/unsubscribe churn
+// is the interesting part - it moves computeds between attached and detached, and
+// a detached computed that fails to re-attach correctly silently stops delivering
+// updates rather than throwing.
+
+type liveEffect = {
+  node: Signal.t<int>,
+  last: ref<int>,
+  disposer: Effect.disposer,
+}
+
+// Plain LCG on floats: the modulus does not fit in ReScript's 32-bit int, and the
+// intermediate product stays well inside the exact range of a double.
+let makeRng = (seed: int) => {
+  let modulus = 4294967296.0
+  let state = ref(seed->Int.toFloat)
+  () => {
+    let next = state.contents *. 1664525.0 +. 1013904223.0
+    state := next -. Math.floor(next /. modulus) *. modulus
+    (state.contents /. 65536.0)->Math.floor->Float.toInt
+  }
+}
+
+let runTrials = (~seed: int, ~trials: int): int => {
+  let violations = ref(0)
+  let rng = makeRng(seed)
+  let below = n => mod(rng(), n)
+
+  for _ in 1 to trials {
+    let signals = []
+    for _ in 1 to 3 + below(3) {
+      signals->Array.push(Signal.make(below(10)))
+    }
+
+    let nodes = []
+    signals->Array.forEach(s => nodes->Array.push(s))
+    let computeds = []
+
+    for _ in 1 to 2 + below(6) {
+      let a = nodes->Array.getUnsafe(below(nodes->Array.length))
+      let b = nodes->Array.getUnsafe(below(nodes->Array.length))
+      let op = below(3)
+      let compute = () => {
+        let x = Signal.get(a)
+        let y = Signal.get(b)
+        switch op {
+        | 0 => x + y
+        | 1 => x * 2 - y
+        | _ => x > y ? x : y
+        }
+      }
+      // Mix plain computeds with equality-carrying ones: they take different
+      // notification paths (equality computeds defer their effects).
+      let c = below(10) < 3 ? Computed.make(compute, ~equals=(p, n) => p == n) : Computed.make(compute)
+      computeds->Array.push(c)
+      nodes->Array.push(c)
+    }
+
+    let live: array<liveEffect> = []
+
+    for _ in 1 to 40 {
+      switch below(6) {
+      | 0 =>
+        let node = computeds->Array.getUnsafe(below(computeds->Array.length))
+        let last = ref(0)
+        let disposer = Effect.runWithDisposer(() => {
+          last := Signal.get(node)
+          None
+        })
+        live->Array.push({node, last, disposer})
+      | 1 =>
+        if live->Array.length > 0 {
+          let idx = below(live->Array.length)
+          switch live->Array.get(idx) {
+          | Some(entry) =>
+            entry.disposer.dispose()
+            let _ = live->Array.splice(~start=idx, ~remove=1, ~insert=[])
+          | None => ()
+          }
+        }
+      | 2 =>
+        let target = signals->Array.getUnsafe(below(signals->Array.length))
+        Signal.set(target, below(20))
+      | 3 =>
+        let _ = Signal.get(computeds->Array.getUnsafe(below(computeds->Array.length)))
+      | 4 =>
+        let count = 1 + below(3)
+        Signal.batch(() => {
+          for _ in 1 to count {
+            let target = signals->Array.getUnsafe(below(signals->Array.length))
+            Signal.set(target, below(20))
+          }
+        })
+      | _ =>
+        let _ = Signal.peek(computeds->Array.getUnsafe(below(computeds->Array.length)))
+      }
+
+      live->Array.forEach(entry => {
+        if entry.last.contents !== Signal.get(entry.node) {
+          violations := violations.contents + 1
+        }
+      })
+    }
+
+    live->Array.forEach(entry => entry.disposer.dispose())
+  }
+
+  violations.contents
+}
+
+let tests = Suite.make(
+  "Reactivity Property Tests",
+  [
+    Test.make("subscribed effects always observe the settled value", () => {
+      let results = [1, 2, 3, 4, 5, 6, 7, 8]->Array.map(seed => {
+        let violations = runTrials(~seed, ~trials=150)
+        Assert.equal(
+          violations,
+          0,
+          ~message=`Seed ${seed->Int.toString} produced ${violations->Int.toString} stale-effect violations`,
+        )
+      })
+      Assert.combineResults(results)
+    }),
+  ],
+)

--- a/packages/rescript-signals/tests/RunTests.res
+++ b/packages/rescript-signals/tests/RunTests.res
@@ -1,4 +1,10 @@
 open Zekr
 
 // Run all test suites
-Runner.runSuites([SignalTests.tests, ComputedTests.tests, EffectTests.tests])
+Runner.runSuites([
+  SignalTests.tests,
+  ComputedTests.tests,
+  EffectTests.tests,
+  LifecycleTests.tests,
+  PropertyTests.tests,
+])


### PR DESCRIPTION
## Problem

`Computed.make` linked the new computed into its sources' subscriber chains at construction and never unlinked it. There was no auto-disposal — the only escape was calling `Computed.dispose` by hand.

That is fine for a graph built once at module level. It is not fine for deriving values inside a render function or any helper called repeatedly, where the source outlives the derived value.

**Memory.** A pinned computed stays reachable from its source through the link chain, and `link.observer.compute` retains its last computed value:

| 20,000 dropped computeds over a live signal | before | after |
|---|---|---|
| each producing an int | 10.45 MB | 0.07 MB |
| each producing a 10k-element array | 1,526 MB | 0.07 MB |

Retention scales with what you derive, not with the size of the graph.

**Writes.** `notifySubs` walks every subscriber, and a non-zero `computedSubscriberCount` also disqualifies the signal from its fast path, so the core write path degraded without bound:

| dead computeds on a signal | 100 writes (before) | 100 writes (after) |
|---|---|---|
| 0 | 0.01 ms | 0.01 ms |
| 1,000 | 5.37 ms | 0.02 ms |
| 20,000 | 30.48 ms | 0.01 ms |

A full subscribe/unsubscribe cycle leaked too — 500 mount/unmount rounds left 500 links behind.

This also affected `SignalsReact`: `useComputed` and `useComputedWithDeps` build a `Computed` in `useMemo` with no disposal, so every unmount leaked one, and `useComputedWithDeps` leaked another on every deps change. Both are fixed by this change with no API change.

## Approach

A computed now attaches to its sources only while it has at least one subscriber, and detaches when the last one goes away. `unlinkFromSubs` already touched only the subscriber chain, so the dependency chain survives detaching and the computed can go hot again later.

- `Link` gains `attached` (whether it currently sits in the source's subscriber chain) and `lastSourceVersion` (the source's version when this dependency was last read).
- `linkToSubs` / `unlinkFromSubs` drive the attach/detach transition and cascade through computed chains.
- While detached, freshness comes from comparing each source's version against `lastSourceVersion` rather than from the dirty flag, since no notifications arrive. This keeps unrelated writes from forcing a recompute — verified: 1 unrelated write plus 3 reads causes 0 recomputes.
- `Computed.dispose` is now only needed to detach a computed that still has subscribers, and no longer leaves it permanently stale — it rebuilds its dependencies on the next read.

The two `perf:` commits keep the hot paths structurally identical to `main`, so detaching costs nothing when nothing detaches:

- State is stored as **detached** rather than attached, so a settled computed carries no flags at all and `Signal.get` tests dirty and detached in one mask — the same single test this path did before.
- Dependency reuse during a recompute does not maintain `lastSourceVersion` at all. Only a detached computed reads it, so the whole chain is stamped right after a detached recompute instead: O(deps) on a path that just ran the compute function, rather than a store per dependency read.

One subtlety worth flagging for review: going hot deliberately does **not** mark the computed dirty. Attaching only ever happens from inside `Signal.get`, which settles freshness before tracking, so a computed going hot is already current. Marking it dirty is also actively wrong — `notifySubs` uses the dirty flag as its "already propagated" marker, so a computed dirtied out of band swallows later notifications instead of passing them downstream. An earlier revision of this branch did exactly that and dropped effect updates; the property test below was written from that failure and fails against it.

## Verification

- 62 → 63 tests pass. 10 new lifecycle tests; 7 of them fail on `main` and pass here. The 3 that pass on both are correctness-preservation checks.
- New randomized property test (fixed-seed LCG, 8 seeds × 150 trials) asserting that once an operation settles, every subscribed effect has observed the current value of what it watches. This is what caught the bug described above.
- Differential fuzz against `main` — 12 seeds × 300 random graphs, ~135k observations each: every `Signal.get`/`Signal.peek` value, every final state, and the multiset of effect firings are unchanged.
- Invariant sweep over 12,000 trials / 732k checks: 0 violations, matching `main`.

**Known behavioral difference:** ordering between *sibling* effects within a single flush can differ from `main` — each still runs exactly once with the correct settled value, but the order two independent effects at the same level run in follows subscriber insertion order, which attaching and detaching changes.

## Performance

Measured by the CI benchmark job across the three commits on this branch:

| commit | overall vs main |
|---|---|
| `186ccbd` lifecycle fix alone | +6.81% |
| `b91753a` skip source version writes while attached | +5.38% |
| `855ae28` single-mask read + stamp after detached recompute | **+0.99%** |

At `855ae28` the framework comparison also moves ReScript Signals from 4th to **3rd, ahead of Vue**, and `createComputations` (−22.8%) and `cellx2500` (−24.3%) come out ahead of `main`.

A note on method, since it changed the conclusion twice: local microbenchmarks in my dev container were worthless here. Running `main` against *itself* produced deltas of +0.88%, +4.29%, +3.63% and −4.70% — a ~9-point spread for identical code. An earlier revision of this PR body quoted local numbers claiming the hot-path cost was within noise; that was wrong, and the CI benchmark is what showed it. Every performance number above comes from the CI runner. The remaining +0.99% is inside CI's own run-to-run variation, so the honest reading is "no measurable regression," not "0.99% slower."

## Behavior change

A detached computed re-runs its compute function more often than a pinned one did, so an impure compute function will be called a different number of times. Worth a changelog note, and arguably a minor rather than a patch.

## Docs

Corrected the claim that computeds are "lazily evaluated" — the initial computation is eager, measured — and documented the attach/detach lifetime in both the package README and the API docs page.
